### PR TITLE
Forward registrations to Sock Shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ detection logic, and another toggles SQLAlchemy debug logging:
 - `DB_ECHO` – set to `true` to log SQL statements (default `false`).
 - `ACCESS_TOKEN_EXPIRE_MINUTES` – lifetime of issued JWT tokens in minutes
   (default `30`).
+- `REGISTER_WITH_SHOP` – set to `true` to also register the account with Sock Shop (default `false`).
+- `SOCK_SHOP_URL` – base URL for Sock Shop when forwarding registrations (default `http://localhost:8080`).
 
 Example `.env`:
 
@@ -38,6 +40,10 @@ FAIL_WINDOW_SECONDS=60
 DB_ECHO=true
 # JWT token expiry in minutes
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+# Forward successful registrations to Sock Shop
+REGISTER_WITH_SHOP=true
+# Where the Sock Shop API is hosted
+SOCK_SHOP_URL=http://localhost:8080
 ```
 
 ## Running the backend

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -51,3 +51,23 @@ def test_login_uses_expire_setting(monkeypatch):
     assert resp.status_code == 200
     assert resp.json()['access_token'] == 'tok'
     assert captured['delta'] == timedelta(minutes=5)
+
+
+def test_register_forward(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json, timeout=3):
+        captured['url'] = url
+        captured['payload'] = json
+        class R:
+            status_code = 200
+        return R()
+
+    monkeypatch.setattr(auth_module.requests, 'post', fake_post)
+    monkeypatch.setenv('REGISTER_WITH_SHOP', 'true')
+    monkeypatch.setenv('SOCK_SHOP_URL', 'http://shop')
+
+    resp = client.post('/register', json={'username': 'carol', 'password': 'pw'})
+    assert resp.status_code == 200
+    assert captured['url'] == 'http://shop/register'
+    assert captured['payload'] == {'username': 'carol', 'password': 'pw'}


### PR DESCRIPTION
## Summary
- mirror successful registrations to Sock Shop when enabled
- add REGISTER_WITH_SHOP and SOCK_SHOP_URL config options
- test that registration is forwarded

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68624248b6e4832ea22263c0bbd88f08