### PR TITLE
Add Mininet traffic generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,22 @@ cd backend
 PYTHONPATH=. pytest
 ```
 
+## Local traffic generation with Mininet
+
+To emulate traffic directly on a Raspberry Pi or other host install
+[Mininet](http://mininet.org/) and run the helper script in the `mininet`
+directory:
+
+```bash
+sudo python3 mininet/gen_traffic.py
+```
+
+The script creates two virtual hosts connected by a switch. One host runs a
+simple Python HTTP server while the other issues a few baseline requests followed
+by a larger burst to mimic attack traffic. After sending the requests you will
+be dropped into the Mininet CLI where additional commands such as `pingall` or
+`iperf` can be used. Type `exit` to shut down the network.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/mininet/README.md
+++ b/mininet/README.md
@@ -1,0 +1,13 @@
+# Mininet Traffic Generation
+
+This example script creates a tiny Mininet topology on the local machine. It starts two hosts connected to a single switch, then generates a burst of HTTP traffic. A small Python HTTP server runs on `h2` while `h1` issues requests.
+
+Run the script with root privileges so Mininet can configure network namespaces:
+
+```bash
+sudo python3 gen_traffic.py
+```
+
+After sending a few baseline requests and a larger "attack" burst, the script drops to the Mininet CLI. Use commands like `pingall` or `iperf` to interact with the virtual network. Type `exit` to stop the network.
+
+This provides a lightweight way to produce repeatable traffic patterns when testing the detector on a Raspberry Pi or other host.

--- a/mininet/gen_traffic.py
+++ b/mininet/gen_traffic.py
@@ -1,0 +1,40 @@
+from mininet.net import Mininet
+from mininet.node import OVSSwitch
+from mininet.cli import CLI
+from mininet.link import TCLink
+from mininet.log import setLogLevel
+import time
+
+
+def run():
+    """Spin up a simple topology and generate HTTP traffic."""
+    setLogLevel('info')
+
+    net = Mininet(link=TCLink, switch=OVSSwitch)
+    h1 = net.addHost('h1')
+    h2 = net.addHost('h2')
+    s1 = net.addSwitch('s1')
+    net.addLink(h1, s1)
+    net.addLink(h2, s1)
+    net.start()
+
+    # Start a basic HTTP server on h2
+    h2.cmd('python3 -m http.server 8080 &')
+
+    # Give the server time to start
+    time.sleep(1)
+
+    print("Sending baseline traffic")
+    for _ in range(5):
+        h1.cmd('curl -s http://10.0.0.2:8080 > /dev/null')
+
+    print("Sending attack traffic")
+    for _ in range(50):
+        h1.cmd('curl -s http://10.0.0.2:8080 > /dev/null')
+
+    CLI(net)
+    net.stop()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add example Mininet traffic generator script
- document how to run the script
- mention Mininet usage in the README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863a0578ae4832ea6aa95c084220562