### PR TITLE
Update branding to APIShield+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# API Security Demo
+# APIShield+ Demo
 
 This repository contains a small FastAPI service used to detect credential stuffing attempts and a React dashboard for viewing alerts.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from app.api.auth import router as auth_router
 from app.api.config import router as config_router
 from app.api.security import router as security_router
 
-app = FastAPI(title="Credential-Stuffing Detector")
+app = FastAPI(title="APIShield+")
 
 # DEVELOPMENT: allow your React dev server to talk to FastAPI
 app.add_middleware(

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>APIShield+ Dashboard</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "APIShield+",
+  "name": "APIShield+ Dashboard",
   "icons": [
     {
       "src": "favicon.ico",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,7 +22,7 @@ function App() {
 
   return (
     <div className="app-container">
-      <h1 className="dashboard-header">Credential-Stuffing &amp; Alerts Dashboard</h1>
+      <h1 className="dashboard-header">APIShield+ Dashboard</h1>
       <ScoreForm onNewAlert={() => setRefreshKey(k => k + 1)} />
       <AlertsChart token={token} />
       <AlertsTable refresh={refreshKey} token={token} />

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -17,7 +17,7 @@ function Dashboard() {
 
   return (
     <div style={{ padding: "1rem" }}>
-      <h1>Credential‐Stuffing &amp; Alerts Dashboard</h1>
+      <h1>APIShield+ Dashboard</h1>
       <p>Backend ping says: {ping ?? "Loading…"} </p>
 
       <ScoreForm />

--- a/rpi/RasberryPiReadme.md
+++ b/rpi/RasberryPiReadme.md
@@ -1,6 +1,6 @@
 # Raspberry Pi Setup Guide
 
-This document describes how to run the API security demo on a Raspberry Pi 4. These instructions cover the edge-hosted monitoring web service only (backend and frontend). The other optional Pi integrations mentioned in the main README are beyond the scope of this file.
+This document describes how to run the APIShield+ demo on a Raspberry Pi 4. These instructions cover the edge-hosted monitoring web service only (backend and frontend). The other optional Pi integrations mentioned in the main README are beyond the scope of this file.
 
 ## Educational use only
 


### PR DESCRIPTION
## Summary
- rename project references to APIShield+
- update dashboard headers and metadata
- adjust Raspberry Pi guide wording

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68661f0e0804832eaba4b70cb3f4a6d8