### PR TITLE
Add token logging and demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ Send a `POST` request to `/login` with a JSON body containing a `username` and `
 
 Include this token in the `Authorization: Bearer <token>` header when calling protected routes such as `/api/alerts`. Token creation and verification happen in `app.core.security`.
 
+### Demonstrating token validation
+
+Run `python scripts/demo_auth.py` after starting the API to see how a valid JWT grants access while a random token is rejected. The script prints the status codes for both attempts and the issued token appears in the server logs thanks to the new middleware.
+
 ## User registration
 
 Create an account by sending a `POST` request to `/register` with JSON fields `username` and `password`. The password is securely hashed before storing in the database. After registering, obtain a token from `/login` and include it in `Authorization` headers when calling secured APIs.

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,16 @@
+import logging
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger("api_logger")
+logging.basicConfig(level=logging.INFO)
+
+class APILoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        token = request.headers.get("Authorization")
+        if token:
+            logger.info("%s %s Authorization=%s", request.method, request.url.path, token)
+        else:
+            logger.info("%s %s", request.method, request.url.path)
+        response = await call_next(request)
+        return response

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Any, Union
+import logging
 
 from jose import jwt, JWTError
 from passlib.context import CryptContext
@@ -27,13 +28,17 @@ def create_access_token(
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES))
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    token = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    logging.info("Issued token for %s: %s", data.get("sub"), token)
+    return token
 
 def decode_access_token(token: str) -> dict[str, Any]:
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        logging.info("Decoded token: %s", token)
         return payload
     except JWTError as e:
+        logging.warning("Invalid token attempted: %s", token)
         raise
 
 # Track revoked tokens so /logout can invalidate them

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.zero_trust import ZeroTrustMiddleware
+from app.core.logging import APILoggingMiddleware
 
 from app.api.score import router as score_router
 from app.api.alerts import router as alerts_router
@@ -20,6 +21,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Log incoming requests and any presented Authorization headers
+app.add_middleware(APILoggingMiddleware)
 
 # Enforce Zero Trust API key if configured
 app.add_middleware(ZeroTrustMiddleware)

--- a/scripts/demo_auth.py
+++ b/scripts/demo_auth.py
@@ -1,0 +1,21 @@
+import os
+import requests
+
+API_BASE = os.environ.get("API_BASE", "http://localhost:8001")
+
+# Register and login to obtain a valid token
+r = requests.post(f"{API_BASE}/register", json={"username": "demo", "password": "demo"})
+r.raise_for_status()
+login = requests.post(f"{API_BASE}/login", json={"username": "demo", "password": "demo"})
+login.raise_for_status()
+valid_token = login.json()["access_token"]
+print("Received valid token", valid_token)
+
+# Call a protected endpoint with the valid token
+resp = requests.get(f"{API_BASE}/api/alerts", headers={"Authorization": f"Bearer {valid_token}"})
+print("Valid token status", resp.status_code)
+
+# Now try with a random/invalid token
+invalid_token = "invalid." * 3
+resp = requests.get(f"{API_BASE}/api/alerts", headers={"Authorization": f"Bearer {invalid_token}"})
+print("Invalid token status", resp.status_code)


### PR DESCRIPTION
## Summary
- add middleware to log Authorization headers
- show tokens issued and decoded
- raise an alert when an invalid token is used
- document a demo script for showcasing token validation

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d45b19d84832ea52c38c6f321384a