### PR TITLE
Add Sock Shop data retrieval to attack sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,17 @@ The React application will be available at [http://localhost:3000](http://localh
 
    The dashboard will be served at <http://localhost:3000>.
 
-2. Log in and locate the **Credential Stuffing Simulation** section. Click
-   **Send Attempt** multiple times to generate failed login requests against the
-   backend. The UI displays how many attempts were blocked once the detection
-   threshold is reached.
+   The dashboard shows two demo accounts, **Alice** and **Ben**. Selecting an
+   account displays how secure it is as a progress bar and lists the enabled
+   protections. Alice intentionally has reduced security while Ben has all
+   security features enabled. When a login succeeds the simulator fetches the
+   user's cart and orders from Sock Shop, demonstrating how Alice's data is
+   exposed while Ben remains safe.
+
+2. Log in and locate the **Credential Stuffing Simulation** section. Choose a
+   target account and click **Start Attack**. When targeting Alice the attack
+   will usually succeed quickly. Ben's account requires the correct chain token
+   so repeated guesses are blocked.
 
 3. To use the command-line to login and create a user that would be used across the services and for the 
    purpose of testing we need to use the terminal, below is an example of how to register a user and login
@@ -134,6 +141,10 @@ The React application will be available at [http://localhost:3000](http://localh
   $ curl -X POST http://localhost:8001/register \
     -H "Content-Type: application/json" \
     -d '{"username":"alice","password":"secret"}'
+
+  $ curl -X POST http://localhost:8001/register \
+    -H "Content-Type: application/json" \
+    -d '{"username":"ben","password":"SuperSecure1!"}'
   ```
    After registering with the detector service, send the same credentials to
    Sock Shop so both backends share the account:
@@ -142,6 +153,10 @@ The React application will be available at [http://localhost:3000](http://localh
    curl -X POST http://localhost:8080/register \
      -H "Content-Type: application/json" \
      -d '{"username":"alice","password":"secret"}'
+
+   curl -X POST http://localhost:8080/register \
+     -H "Content-Type: application/json" \
+     -d '{"username":"ben","password":"SuperSecure1!"}'
    ```
   and to login we would either login from the react-native application or we would enter in the command below
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "cross-env REACT_APP_API_BASE=http://localhost:8001 react-scripts start",
-    "build": "cross-env REACT_APP_API_BASE=http://localhost:8001 react-scripts build",
-    "test": "cross-env REACT_APP_API_BASE=http://localhost:8001 react-scripts test",
+    "start": "cross-env REACT_APP_API_BASE=http://localhost:8001 REACT_APP_SHOP_URL=http://localhost:8080 react-scripts start",
+    "build": "cross-env REACT_APP_API_BASE=http://localhost:8001 REACT_APP_SHOP_URL=http://localhost:8080 react-scripts build",
+    "test": "cross-env REACT_APP_API_BASE=http://localhost:8001 REACT_APP_SHOP_URL=http://localhost:8080 react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -115,3 +115,43 @@ body {
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
 }
+
+.user-accounts {
+  margin-bottom: 1.5rem;
+  background-color: #ffffff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
+}
+
+.user-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.user-buttons button {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #ccc;
+  background: #eee;
+  cursor: pointer;
+}
+
+.user-buttons button.active {
+  background: #6200ea;
+  color: #fff;
+}
+
+.progress {
+  width: 100%;
+  background: #eee;
+  height: 10px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.progress > div {
+  height: 100%;
+  background: #6200ea;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,11 +5,13 @@ import AlertsChart from "./AlertsChart";
 import SecurityToggle from "./SecurityToggle";
 import LoginForm from "./LoginForm";
 import AttackSim from "./AttackSim";
+import UserAccounts from "./UserAccounts";
 import "./App.css";
 
 function App() {
   const [refreshKey, setRefreshKey] = useState(0);
   const [token, setToken] = useState(localStorage.getItem("token"));
+  const [selectedUser, setSelectedUser] = useState("alice");
 
   if (!token) {
     return (
@@ -23,11 +25,12 @@ function App() {
   return (
     <div className="app-container">
       <h1 className="dashboard-header">APIShield+ Dashboard</h1>
+      <UserAccounts onSelect={setSelectedUser} />
       <ScoreForm onNewAlert={() => setRefreshKey(k => k + 1)} />
       <AlertsChart token={token} />
       <AlertsTable refresh={refreshKey} token={token} />
       <div className="attack-section">
-        <AttackSim />
+        <AttackSim user={selectedUser} />
         <div className="security-box">
           <SecurityToggle />
         </div>

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -1,6 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { USER_DATA } from "./UserAccounts";
 
 const API_BASE = process.env.REACT_APP_API_BASE || "";
+const SHOP_URL = process.env.REACT_APP_SHOP_URL || "http://localhost:8080";
 
 const DUMMY_PASSWORDS = [
   "wrongpass",
@@ -10,8 +12,36 @@ const DUMMY_PASSWORDS = [
   "letmein",
 ];
 
-export default function AttackSim() {
-  const [targetUser, setTargetUser] = useState("alice");
+export default function AttackSim({ user }) {
+  const [targetUser, setTargetUser] = useState(user || "alice");
+
+  useEffect(() => {
+    if (user) {
+      setTargetUser(user);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    async function ensureUsers() {
+      for (const [name, info] of Object.entries(USER_DATA)) {
+        try {
+          await fetch(`${API_BASE}/register`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ username: name, password: info.password }),
+          });
+          await fetch(`${SHOP_URL}/register`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ username: name, password: info.password }),
+          });
+        } catch (err) {
+          // ignore errors (likely already registered)
+        }
+      }
+    }
+    ensureUsers();
+  }, []);
   const [attemptsInput, setAttemptsInput] = useState(20);
   const [running, setRunning] = useState(false);
   const [results, setResults] = useState(null);
@@ -36,6 +66,8 @@ export default function AttackSim() {
     let firstAttempt = null;
     let firstTime = null;
     let firstInfo = null;
+    let firstCart = null;
+    let firstOrders = null;
 
     const start = performance.now();
 
@@ -56,6 +88,19 @@ export default function AttackSim() {
         }
       } catch (err) {
         console.error("Login error", err);
+      }
+
+      let shopOk = false;
+      try {
+        const shopResp = await fetch(`${SHOP_URL}/login`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username: targetUser, password: pwd }),
+          credentials: "include",
+        });
+        shopOk = shopResp.status === 200;
+      } catch (err) {
+        console.error("Shop login error", err);
       }
 
       try {
@@ -102,6 +147,23 @@ export default function AttackSim() {
         }
       }
 
+      if (shopOk && firstCart === null) {
+        try {
+          const cartResp = await fetch(`${SHOP_URL}/carts/${targetUser}/items`);
+          if (cartResp.ok) {
+            firstCart = await cartResp.json();
+          }
+          const orderResp = await fetch(
+            `${SHOP_URL}/orders/search/customerId?custId=${targetUser}`
+          );
+          if (orderResp.ok) {
+            firstOrders = await orderResp.json();
+          }
+        } catch (err) {
+          console.error("Fetch shop info", err);
+        }
+      }
+
       setResults({
         attempts: i + 1,
         successes,
@@ -109,6 +171,8 @@ export default function AttackSim() {
         first_success_attempt: firstAttempt,
         first_success_time: firstTime,
         first_user_info: firstInfo,
+        first_cart: firstCart,
+        first_orders: firstOrders,
       });
 
       await new Promise((res) => setTimeout(res, 100));
@@ -125,10 +189,10 @@ export default function AttackSim() {
       <div className="attack-controls">
         <label>
           Target User:
-          <input
-            value={targetUser}
-            onChange={(e) => setTargetUser(e.target.value)}
-          />
+          <select value={targetUser} onChange={(e) => setTargetUser(e.target.value)}>
+            <option value="alice">Alice</option>
+            <option value="ben">Ben</option>
+          </select>
         </label>
         <label>
           Attempts:
@@ -156,8 +220,18 @@ export default function AttackSim() {
               </p>
               {results.first_user_info && (
                 <p>
-                  User Info:{' '}
+                  User Info{' '}
                   <code>{JSON.stringify(results.first_user_info)}</code>
+                </p>
+              )}
+              {results.first_cart && (
+                <p>
+                  Cart <code>{JSON.stringify(results.first_cart)}</code>
+                </p>
+              )}
+              {results.first_orders && (
+                <p>
+                  Orders <code>{JSON.stringify(results.first_orders)}</code>
                 </p>
               )}
             </>

--- a/frontend/src/UserAccounts.jsx
+++ b/frontend/src/UserAccounts.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+
+export const USER_DATA = {
+  alice: {
+    name: "Alice",
+    password: "secret",
+    security: 30,
+    features: [
+      "Weak password",
+      "No MFA",
+      "Token reuse allowed",
+    ],
+  },
+  ben: {
+    name: "Ben",
+    password: "SuperSecure1!",
+    security: 90,
+    features: [
+      "Strong password requirements",
+      "MFA enabled",
+      "Rotating chain token",
+    ],
+  },
+};
+
+export default function UserAccounts({ onSelect }) {
+  const [active, setActive] = useState("alice");
+
+  const select = (u) => {
+    setActive(u);
+    if (onSelect) onSelect(u);
+  };
+
+  const info = USER_DATA[active];
+
+  return (
+    <div className="user-accounts">
+      <div className="user-buttons">
+        {Object.keys(USER_DATA).map((u) => (
+          <button
+            key={u}
+            onClick={() => select(u)}
+            className={active === u ? "active" : ""}
+          >
+            {USER_DATA[u].name}
+          </button>
+        ))}
+      </div>
+      <div className="user-info">
+        <h3>{info.name} Security</h3>
+        <div className="progress">
+          <div style={{ width: `${info.security}%` }} />
+        </div>
+        <p>{info.security}% safe</p>
+        <ul>
+          {info.features.map((f) => (
+            <li key={f}>{f}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show security levels with a progress bar for each demo account
- pre-register Alice and Ben on startup and fetch their cart/orders during attacks
- wire the shop URL through the build scripts
- document registering both users for the simulation

## Testing
- `PYTHONPATH=backend pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `CI=true npm test --silent` *(no output)*


------
https://chatgpt.com/codex/tasks/task_e_686d506e0044832e84c6fb1e956a83a1