### PR TITLE
Add Zero Trust policy middleware and RBAC

### DIFF
--- a/backend/alembic/versions/ccccc_add_role_to_users_table.py
+++ b/backend/alembic/versions/ccccc_add_role_to_users_table.py
@@ -1,0 +1,24 @@
+"""add role column to users table
+
+Revision ID: ccccc
+Revises: bb1f5f0e5d4a
+Create Date: 2025-06-13 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'ccccc'
+down_revision: Union[str, None] = 'bb1f5f0e5d4a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('role', sa.String(), nullable=False, server_default='user'))
+    op.alter_column('users', 'role', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'role')

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -29,7 +29,8 @@ def register(user_in: UserCreate, db: Session = Depends(get_db)):
     if get_user_by_username(db, user_in.username):
         raise HTTPException(status_code=400, detail="Username already registered")
     hashed = get_password_hash(user_in.password)
-    user = create_user(db, username=user_in.username, password_hash=hashed)
+    role = user_in.role or "user"
+    user = create_user(db, username=user_in.username, password_hash=hashed, role=role)
 
     if os.getenv("REGISTER_WITH_SHOP", "false").lower() in {"1", "true", "yes"}:
         shop_url = os.getenv("SOCK_SHOP_URL", "http://localhost:8080").rstrip("/")

--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -1,14 +1,15 @@
 # app/api/config.py
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 import os
 
 from app.api.score import DEFAULT_FAIL_LIMIT
+from app.api.dependencies import require_role
 
 router = APIRouter(tags=["config"])
 
 
 @router.get("/config")
-def get_config():
+def get_config(_user=Depends(require_role("admin"))):
     """Return the current FAIL_LIMIT configuration value."""
     fail_limit = int(os.getenv("FAIL_LIMIT", DEFAULT_FAIL_LIMIT))
     return {"fail_limit": fail_limit}

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -40,3 +40,12 @@ async def get_current_user(
     if not user:
         raise credentials_exception
     return user
+
+
+def require_role(required: str):
+    def checker(user=Depends(get_current_user)):
+        if user.role != required:
+            raise HTTPException(status_code=403, detail="Insufficient role")
+        return user
+
+    return checker

--- a/backend/app/api/security.py
+++ b/backend/app/api/security.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 import hashlib
 import secrets
 
 from app.core.config import settings
+from app.api.dependencies import require_role
 
 # Global flag controlling credential stuffing enforcement
 SECURITY_ENABLED = True
@@ -48,18 +49,18 @@ init_chain()
 router = APIRouter(prefix="/api/security", tags=["security"])
 
 @router.get("/")
-def get_security():
+def get_security(_user=Depends(require_role("admin"))):
     """Return current security enforcement state."""
     return {"enabled": SECURITY_ENABLED}
 
 
 @router.get("/chain")
-def get_chain():
+def get_chain(_user=Depends(require_role("admin"))):
     """Retrieve the current chain value."""
     return {"chain": CURRENT_CHAIN}
 
 @router.post("/")
-def set_security(payload: dict):
+def set_security(payload: dict, _user=Depends(require_role("admin"))):
     """Update security enforcement state."""
     enabled = payload.get("enabled")
     if not isinstance(enabled, bool):

--- a/backend/app/core/policy.py
+++ b/backend/app/core/policy.py
@@ -1,0 +1,46 @@
+import os
+from datetime import datetime, timedelta
+from fastapi import Request
+from sqlalchemy.orm import Session
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_403_FORBIDDEN
+
+from app.models.alerts import Alert
+
+FAIL_LIMIT = int(os.getenv("FAIL_LIMIT", 5))
+FAIL_WINDOW_SECONDS = int(os.getenv("FAIL_WINDOW_SECONDS", 60))
+
+
+def assess_risk(db: Session, request: Request) -> bool:
+    """Return True if request is allowed based on recent failures."""
+    since = datetime.utcnow() - timedelta(seconds=FAIL_WINDOW_SECONDS)
+    count = (
+        db.query(Alert)
+        .filter(Alert.ip_address == request.client.host, Alert.timestamp >= since)
+        .count()
+    )
+    return count < FAIL_LIMIT
+
+
+class PolicyEngineMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        request = Request(scope, receive=receive)
+        if request.url.path == "/score":
+            await self.app(scope, receive, send)
+            return
+        # Create DB session lazily to avoid overhead
+        from app.core.db import SessionLocal
+
+        with SessionLocal() as db:
+            allowed = assess_risk(db, request)
+        if not allowed:
+            response = JSONResponse({"detail": "Request denied by policy"}, status_code=HTTP_403_FORBIDDEN)
+            await response(scope, receive, send)
+            return
+        await self.app(scope, receive, send)

--- a/backend/app/crud/users.py
+++ b/backend/app/crud/users.py
@@ -6,8 +6,8 @@ def get_user_by_username(db: Session, username: str) -> User | None:
     return db.query(User).filter(User.username == username).first()
 
 
-def create_user(db: Session, username: str, password_hash: str) -> User:
-    user = User(username=username, password_hash=password_hash)
+def create_user(db: Session, username: str, password_hash: str, role: str = "user") -> User:
+    user = User(username=username, password_hash=password_hash, role=role)
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ import os
 from app.core.zero_trust import ZeroTrustMiddleware
 from app.core.logging import APILoggingMiddleware
 from app.core.anomaly import AnomalyDetectionMiddleware
+from app.core.policy import PolicyEngineMiddleware
 
 from app.api.score import router as score_router
 from app.api.alerts import router as alerts_router
@@ -29,6 +30,8 @@ app.add_middleware(APILoggingMiddleware)
 
 # Enforce Zero Trust API key if configured
 app.add_middleware(ZeroTrustMiddleware)
+# Apply risk-based policy engine
+app.add_middleware(PolicyEngineMiddleware)
 
 # Optional ML-driven anomaly detection
 if os.getenv("ANOMALY_DETECTION", "false").lower() == "true":

--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -7,3 +7,4 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, nullable=False, index=True)
     password_hash = Column(String, nullable=False)
+    role = Column(String, nullable=False, default="user")

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -3,10 +3,12 @@ from pydantic import BaseModel
 class UserCreate(BaseModel):
     username: str
     password: str
+    role: str | None = None
 
 class UserRead(BaseModel):
     id: int
     username: str
+    role: str
 
     class Config:
         orm_mode = True

--- a/backend/tests/test_security_toggle.py
+++ b/backend/tests/test_security_toggle.py
@@ -8,6 +8,8 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.core.db import Base, engine, SessionLocal
 from app.api.security import SECURITY_ENABLED
+from app.crud.users import create_user
+from app.core.security import get_password_hash
 
 client = TestClient(app)
 
@@ -18,6 +20,14 @@ def setup_function(_):
     # reset flag for each test
     from app.api import security
     security.SECURITY_ENABLED = True
+    with SessionLocal() as db:
+        create_user(db, username="admin", password_hash=get_password_hash("pw"), role="admin")
+
+
+def _auth_headers():
+    resp = client.post('/login', json={'username': 'admin', 'password': 'pw'})
+    token = resp.json()['access_token']
+    return {'Authorization': f'Bearer {token}'}
 
 
 def teardown_function(_):
@@ -25,22 +35,22 @@ def teardown_function(_):
 
 
 def test_get_security_default():
-    resp = client.get('/api/security')
+    resp = client.get('/api/security', headers=_auth_headers())
     assert resp.status_code == 200
     assert resp.json()['enabled'] is True
 
 
 def test_toggle_security():
-    resp = client.post('/api/security', json={'enabled': False})
+    resp = client.post('/api/security', json={'enabled': False}, headers=_auth_headers())
     assert resp.status_code == 200
     assert resp.json()['enabled'] is False
-    resp = client.get('/api/security')
+    resp = client.get('/api/security', headers=_auth_headers())
     assert resp.json()['enabled'] is False
 
 
 def test_score_not_blocked_when_disabled():
     # disable security
-    client.post('/api/security', json={'enabled': False})
+    client.post('/api/security', json={'enabled': False}, headers=_auth_headers())
     # Send failures exceeding threshold
     for i in range(6):
         resp = client.post('/score', json={'client_ip': '9.9.9.9', 'auth_result': 'failure'})


### PR DESCRIPTION
## Summary
- enforce least-privilege access with a `role` column on `User`
- protect config and security endpoints with role-based checks
- introduce a PolicyEngine middleware for risk-based request blocking
- update CRUD, schemas and auth to handle user roles
- adjust unit tests for new auth requirements
- add migration for `role` column

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711e4ab544832eb45512c42752835d