### PR TITLE
Add per-request reauthentication feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ detection logic, and another toggles SQLAlchemy debug logging:
 - `LOGIN_WITH_SHOP` – set to `true` to also log into Sock Shop when authenticating (default `false`).
 - `SOCK_SHOP_URL` – base URL for Sock Shop when forwarding registrations (default `http://localhost:8080`).
 - `ANOMALY_DETECTION` – set to `true` to enable ML-based request anomaly checks (default `false`).
+- `REAUTH_PER_REQUEST` – set to `true` to require the user's password on every API call (default `false`).
 
 Example `.env`:
 
@@ -50,6 +51,8 @@ LOGIN_WITH_SHOP=true
 SOCK_SHOP_URL=http://localhost:8080
 # Enable ML-based anomaly checks
 ANOMALY_DETECTION=true
+# Require password on every API request
+REAUTH_PER_REQUEST=true
 ```
 
 ## Running the backend

--- a/backend/app/core/re_auth.py
+++ b/backend/app/core/re_auth.py
@@ -1,0 +1,35 @@
+import os
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+from app.core.security import decode_access_token, verify_password
+from app.core.db import SessionLocal
+from app.crud.users import get_user_by_username
+
+REAUTH_REQUIRED = os.getenv("REAUTH_PER_REQUEST", "false").lower() in {"1", "true", "yes"}
+
+class ReAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if not REAUTH_REQUIRED:
+            return await call_next(request)
+        if request.url.path in {"/ping", "/login", "/register", "/api/token"}:
+            return await call_next(request)
+        auth = request.headers.get("Authorization")
+        if not auth or not auth.startswith("Bearer "):
+            return JSONResponse({"detail": "Missing token"}, status_code=HTTP_401_UNAUTHORIZED)
+        token = auth.split()[1]
+        try:
+            payload = decode_access_token(token)
+            username = payload.get("sub")
+        except Exception:
+            return JSONResponse({"detail": "Invalid token"}, status_code=HTTP_401_UNAUTHORIZED)
+        password = request.headers.get("X-Reauth-Password")
+        if not password:
+            return JSONResponse({"detail": "Password required"}, status_code=HTTP_401_UNAUTHORIZED)
+        with SessionLocal() as db:
+            user = get_user_by_username(db, username)
+            if not user or not verify_password(password, user.password_hash):
+                return JSONResponse({"detail": "Invalid credentials"}, status_code=HTTP_401_UNAUTHORIZED)
+        return await call_next(request)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.core.logging import APILoggingMiddleware
 from app.core.anomaly import AnomalyDetectionMiddleware
 from app.core.policy import PolicyEngineMiddleware
 from app.core.metrics import MetricsMiddleware
+from app.core.re_auth import ReAuthMiddleware
 
 from app.api.score import router as score_router
 from app.api.alerts import router as alerts_router
@@ -33,6 +34,7 @@ app.add_middleware(MetricsMiddleware)
 
 # Enforce Zero Trust API key if configured
 app.add_middleware(ZeroTrustMiddleware)
+app.add_middleware(ReAuthMiddleware)
 # Apply risk-based policy engine
 app.add_middleware(PolicyEngineMiddleware)
 


### PR DESCRIPTION
## Summary
- require password on each API call via new `ReAuthMiddleware`
- document `REAUTH_PER_REQUEST` configuration

## Testing
- `pip install -q -r backend/requirements.txt`
- `cd backend && PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b4fdd248832eaa38c8ef5f2a693d