### PR TITLE
Add CLI and tests for per-request password

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ detection logic, and another toggles SQLAlchemy debug logging:
 - `LOGIN_WITH_SHOP` – set to `true` to also log into Sock Shop when authenticating (default `false`).
 - `SOCK_SHOP_URL` – base URL for Sock Shop when forwarding registrations (default `http://localhost:8080`).
 - `ANOMALY_DETECTION` – set to `true` to enable ML-based request anomaly checks (default `false`).
+- `REAUTH_PER_REQUEST` – set to `true` to require the user's password on every API call (default `false`).
+  When enabled, clients must supply the password again via the
+  `X-Reauth-Password` header. The helper script
+  `scripts/reauth_client.py` demonstrates prompting for the password
+  before each request.
 
 Example `.env`:
 
@@ -50,6 +55,8 @@ LOGIN_WITH_SHOP=true
 SOCK_SHOP_URL=http://localhost:8080
 # Enable ML-based anomaly checks
 ANOMALY_DETECTION=true
+# Require password on every API request
+REAUTH_PER_REQUEST=true
 ```
 
 ## Running the backend
@@ -181,9 +188,10 @@ account displays how secure it is as a progress bar and lists the enabled
      -H "Authorization: Bearer <token>"
    ```
    
-For command-line testing there are two standalone scripts:
+For command-line testing there are three standalone scripts:
 
 ```bash
+python scripts/reauth_client.py --help
 python scripts/stuffing.py --help
 python scripts/stuffingwithjwt.py --help
 ```

--- a/backend/app/core/re_auth.py
+++ b/backend/app/core/re_auth.py
@@ -1,0 +1,35 @@
+import os
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+from app.core.security import decode_access_token, verify_password
+from app.core.db import SessionLocal
+from app.crud.users import get_user_by_username
+
+REAUTH_REQUIRED = os.getenv("REAUTH_PER_REQUEST", "false").lower() in {"1", "true", "yes"}
+
+class ReAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if not REAUTH_REQUIRED:
+            return await call_next(request)
+        if request.url.path in {"/ping", "/login", "/register", "/api/token"}:
+            return await call_next(request)
+        auth = request.headers.get("Authorization")
+        if not auth or not auth.startswith("Bearer "):
+            return JSONResponse({"detail": "Missing token"}, status_code=HTTP_401_UNAUTHORIZED)
+        token = auth.split()[1]
+        try:
+            payload = decode_access_token(token)
+            username = payload.get("sub")
+        except Exception:
+            return JSONResponse({"detail": "Invalid token"}, status_code=HTTP_401_UNAUTHORIZED)
+        password = request.headers.get("X-Reauth-Password")
+        if not password:
+            return JSONResponse({"detail": "Password required"}, status_code=HTTP_401_UNAUTHORIZED)
+        with SessionLocal() as db:
+            user = get_user_by_username(db, username)
+            if not user or not verify_password(password, user.password_hash):
+                return JSONResponse({"detail": "Invalid credentials"}, status_code=HTTP_401_UNAUTHORIZED)
+        return await call_next(request)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.core.logging import APILoggingMiddleware
 from app.core.anomaly import AnomalyDetectionMiddleware
 from app.core.policy import PolicyEngineMiddleware
 from app.core.metrics import MetricsMiddleware
+from app.core.re_auth import ReAuthMiddleware
 
 from app.api.score import router as score_router
 from app.api.alerts import router as alerts_router
@@ -33,6 +34,7 @@ app.add_middleware(MetricsMiddleware)
 
 # Enforce Zero Trust API key if configured
 app.add_middleware(ZeroTrustMiddleware)
+app.add_middleware(ReAuthMiddleware)
 # Apply risk-based policy engine
 app.add_middleware(PolicyEngineMiddleware)
 

--- a/backend/tests/test_reauth.py
+++ b/backend/tests/test_reauth.py
@@ -1,0 +1,54 @@
+import importlib
+import os
+
+from fastapi.testclient import TestClient
+from app.core.db import Base, engine, SessionLocal
+from app.core.security import get_password_hash
+from app.crud.users import create_user
+
+
+def _reload_app():
+    import app.core.re_auth
+    import app.main
+    importlib.reload(app.core.re_auth)
+    importlib.reload(app.main)
+    return TestClient(app.main.app)
+
+
+def setup_function(_):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    with SessionLocal() as db:
+        create_user(db, username="alice", password_hash=get_password_hash("pw"))
+
+
+def teardown_function(_):
+    SessionLocal().close()
+
+
+def test_missing_password_header(monkeypatch):
+    monkeypatch.setenv("REAUTH_PER_REQUEST", "true")
+    client = _reload_app()
+
+    token = client.post("/login", json={"username": "alice", "password": "pw"}).json()["access_token"]
+    resp = client.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Password required"
+
+    monkeypatch.setenv("REAUTH_PER_REQUEST", "false")
+    _reload_app()
+
+
+def test_reauth_success(monkeypatch):
+    monkeypatch.setenv("REAUTH_PER_REQUEST", "true")
+    client = _reload_app()
+
+    token = client.post("/login", json={"username": "alice", "password": "pw"}).json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}", "X-Reauth-Password": "pw"}
+    resp = client.get("/api/me", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "alice"
+
+    monkeypatch.setenv("REAUTH_PER_REQUEST", "false")
+    _reload_app()
+

--- a/frontend/src/AlertsChart.jsx
+++ b/frontend/src/AlertsChart.jsx
@@ -10,8 +10,7 @@ import {
   Legend,
 } from "chart.js";
 import { Line } from "react-chartjs-2";
-
-const API_BASE = process.env.REACT_APP_API_BASE || "";
+import { apiFetch } from "./api";
 
 ChartJS.register(
   CategoryScale,
@@ -29,7 +28,7 @@ export default function AlertsChart({ token }) {
 
   const loadStats = async () => {
     try {
-      const resp = await fetch(`${API_BASE}/api/alerts/stats`, {
+      const resp = await apiFetch("/api/alerts/stats", {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (!resp.ok) throw new Error(await resp.text());

--- a/frontend/src/AlertsTable.jsx
+++ b/frontend/src/AlertsTable.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
-
-const API_BASE = process.env.REACT_APP_API_BASE || "";
+import { apiFetch } from "./api";
 
 export default function AlertsTable({ refresh, token }) {
   const [alerts, setAlerts] = useState([]);
@@ -8,7 +7,7 @@ export default function AlertsTable({ refresh, token }) {
 
   const loadAlerts = async () => {
     try {
-      const resp = await fetch(`${API_BASE}/api/alerts`, {
+      const resp = await apiFetch("/api/alerts", {
         headers: { Authorization: `Bearer ${token}` }
       });
       if (!resp.ok) throw new Error(await resp.text());

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { USER_DATA } from "./UserAccounts";
-
-
-const API_BASE = process.env.REACT_APP_API_BASE || "";
+import { apiFetch } from "./api";
 const SHOP_URL = process.env.REACT_APP_SHOP_URL || "http://localhost:8080";
 
 const DUMMY_PASSWORDS = [
@@ -26,7 +24,7 @@ export default function AttackSim({ user }) {
     async function ensureUsers() {
       for (const [name, info] of Object.entries(USER_DATA)) {
         try {
-          await fetch(`${API_BASE}/register`, {
+          await apiFetch("/register", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ username: name, password: info.password }),
@@ -55,7 +53,7 @@ export default function AttackSim({ user }) {
     setError(null);
     let securityEnabled = false;
     try {
-      const secResp = await fetch(`${API_BASE}/api/security`);
+      const secResp = await apiFetch("/api/security");
       if (secResp.ok) {
         const data = await secResp.json();
         securityEnabled = data.enabled;
@@ -78,7 +76,7 @@ export default function AttackSim({ user }) {
       let loginOk = false;
       let token = null;
       try {
-        const resp = await fetch(`${API_BASE}/login`, {
+        const resp = await apiFetch("/login", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ username: targetUser, password: pwd }),
@@ -106,7 +104,7 @@ export default function AttackSim({ user }) {
       }
 
       try {
-        const scoreResp = await fetch(`${API_BASE}/score`, {
+        const scoreResp = await apiFetch("/score", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -136,7 +134,7 @@ export default function AttackSim({ user }) {
           firstTime = (performance.now() - start) / 1000;
           if (token) {
             try {
-              const infoResp = await fetch(`${API_BASE}/api/me`, {
+              const infoResp = await apiFetch("/api/me", {
                 headers: { Authorization: `Bearer ${token}` },
               });
               if (infoResp.ok) {

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-
-const API_BASE = process.env.REACT_APP_API_BASE || "";
+import { apiFetch } from "./api";
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
@@ -11,7 +10,7 @@ export default function LoginForm({ onLogin }) {
     e.preventDefault();
     setError(null);
     try {
-      const resp = await fetch(`${API_BASE}/login`, {
+      const resp = await apiFetch("/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password })

--- a/frontend/src/ScoreForm.jsx
+++ b/frontend/src/ScoreForm.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
-
-const API_BASE = process.env.REACT_APP_API_BASE || "";
+import { apiFetch } from "./api";
 
 const DEFAULT_THRESHOLD = 5;
 
@@ -13,7 +12,7 @@ export default function ScoreForm({ onNewAlert }) {
   useEffect(() => {
     async function fetchConfig() {
       try {
-        const resp = await fetch(`${API_BASE}/config`);
+        const resp = await apiFetch("/config");
         if (resp.ok) {
           const data = await resp.json();
           if (data.fail_limit) {
@@ -34,7 +33,7 @@ export default function ScoreForm({ onNewAlert }) {
 
     try {
       const token = localStorage.getItem("token");
-      const resp = await fetch(`${API_BASE}/score`, {
+      const resp = await apiFetch("/score", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ client_ip: ip, auth_result: result, with_jwt: Boolean(token) })

--- a/frontend/src/SecurityToggle.jsx
+++ b/frontend/src/SecurityToggle.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
-
-const API_BASE = process.env.REACT_APP_API_BASE || "";
+import { apiFetch } from "./api";
 
 export default function SecurityToggle() {
   const [enabled, setEnabled] = useState(true);
@@ -8,7 +7,7 @@ export default function SecurityToggle() {
 
   const loadState = async () => {
     try {
-      const resp = await fetch(`${API_BASE}/api/security`);
+      const resp = await apiFetch("/api/security");
       if (resp.ok) {
         const data = await resp.json();
         setEnabled(data.enabled);
@@ -26,7 +25,7 @@ export default function SecurityToggle() {
 
   const toggle = async () => {
     try {
-      const resp = await fetch(`${API_BASE}/api/security`, {
+      const resp = await apiFetch("/api/security", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ enabled: !enabled })

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,16 @@
+export const API_BASE = process.env.REACT_APP_API_BASE || "";
+
+export async function apiFetch(path, options = {}) {
+  const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
+  let resp = await fetch(url, options);
+  if (resp.status !== 401) {
+    return resp;
+  }
+  const pw = window.prompt("Please enter your password:");
+  if (!pw) {
+    return resp;
+  }
+  const headers = { ...(options.headers || {}), "X-Reauth-Password": pw };
+  resp = await fetch(url, { ...options, headers });
+  return resp;
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,14 +2,13 @@
 import React, { useEffect, useState } from "react";
 import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
-
-const API_BASE = process.env.REACT_APP_API_BASE || "";
+import { apiFetch } from "../api";
 
 function Dashboard() {
   const [ping, setPing] = useState(null);
 
   useEffect(() => {
-    fetch(`${API_BASE}/ping`)
+    apiFetch("/ping")
       .then((res) => res.json())
       .then((data) => setPing(data.message))
       .catch((err) => console.error("Ping failed:", err));

--- a/scripts/reauth_client.py
+++ b/scripts/reauth_client.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Small demo client showing per-request reauthentication."""
+
+import argparse
+import getpass
+import os
+import requests
+
+
+def login(base: str, username: str) -> tuple[str, str]:
+    """Prompt for the initial password and obtain a JWT."""
+    pw = getpass.getpass("Password: ")
+    resp = requests.post(f"{base}/login", json={"username": username, "password": pw}, timeout=5)
+    resp.raise_for_status()
+    token = resp.json()["access_token"]
+    return token, pw
+
+
+def call_me(base: str, token: str) -> None:
+    pw = getpass.getpass("Re-auth password: ")
+    headers = {"Authorization": f"Bearer {token}", "X-Reauth-Password": pw}
+    resp = requests.get(f"{base}/api/me", headers=headers, timeout=5)
+    print(resp.status_code, resp.json())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Demo client requiring the password on every request")
+    parser.add_argument("username", help="Account username")
+    parser.add_argument("--base", default=os.environ.get("API_BASE", "http://localhost:8001"), help="API base URL")
+    parser.add_argument("--times", type=int, default=1, help="Number of requests to send")
+    args = parser.parse_args()
+
+    token, _ = login(args.base, args.username)
+    for _ in range(args.times):
+        call_me(args.base, token)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document the new `X-Reauth-Password` requirement
- add `scripts/reauth_client.py` demo script
- list the new script in the README
- add unit tests covering `ReAuthMiddleware`
- prompt the user for their password in the frontend when a request returns 401

## Testing
- `pip install -q -r backend/requirements.txt`
- `cd backend && PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873b4fdd248832eaa38c8ef5f2a693d