### PR TITLE
Improve reauth setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,19 @@ detection logic, and another toggles SQLAlchemy debug logging:
 - `REAUTH_PER_REQUEST` – set to `true` to require the user's password on every API call (default `false`).
 
 When enabled, clients must supply the password again via the
-  `X-Reauth-Password` header. The helper script
-  `scripts/reauth_client.py` demonstrates prompting for the password
-  before each request.
+`X-Reauth-Password` header. The helper script
+`scripts/reauth_client.py` demonstrates prompting for the password
+before each request.
 
-When enabled, clients must supply the password again via the
-  `X-Reauth-Password` header. The helper script
-  `scripts/reauth_client.py` demonstrates prompting for the password
-  before each request.
+To try it manually, register an account and then run:
+
+```bash
+python scripts/reauth_client.py alice --base http://localhost:8001 --times 2
+```
+
+The script logs in and prompts for your password before every request.
+Set `REAUTH_PER_REQUEST=false` in `.env` if you prefer to disable this
+extra check.
 
 
 Example `.env`:


### PR DESCRIPTION
## Summary
- clarify how to try per-request reauthentication

## Testing
- `python3 -m venv .venv && source .venv/bin/activate && pip install -q -r backend/requirements.txt && cd backend && PYTHONPATH=. pytest -q > ../pytest.log && cd .. && deactivate`
- `tail -n 20 pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68757107260c832eb24393749fb519e1