### PR TITLE
Improve reauth handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,20 @@ detection logic, and another toggles SQLAlchemy debug logging:
 - `REAUTH_PER_REQUEST` – set to `true` to require the user's password on every API call (default `false`).
 
 When enabled, clients must supply the password again via the
-  `X-Reauth-Password` header. The helper script
-  `scripts/reauth_client.py` demonstrates prompting for the password
-  before each request.
+`X-Reauth-Password` header. The helper script
+`scripts/reauth_client.py` demonstrates prompting for the password
+before each request.
 
-When enabled, clients must supply the password again via the
-  `X-Reauth-Password` header. The helper script
-  `scripts/reauth_client.py` demonstrates prompting for the password
-  before each request.
+To try it manually, register an account and then run:
+
+```bash
+python scripts/reauth_client.py alice --base http://localhost:8001 --times 2
+```
+
+The script logs in and prompts for your password before every request.
+Canceling the prompt or entering the wrong password logs you out and
+returns to the login screen. Set `REAUTH_PER_REQUEST=false` in `.env` if
+you prefer to disable this extra check.
 
 
 Example `.env`:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,16 +1,32 @@
 export const API_BASE = process.env.REACT_APP_API_BASE || "";
 
+export function logout() {
+  localStorage.removeItem("token");
+  window.location.reload();
+}
+
 export async function apiFetch(path, options = {}) {
   const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
   let resp = await fetch(url, options);
-  if (resp.status !== 401) {
+  if (
+    resp.status !== 401 ||
+    url.endsWith("/login") ||
+    url.endsWith("/register") ||
+    url.endsWith("/api/token")
+  ) {
     return resp;
   }
+
   const pw = window.prompt("Please enter your password:");
   if (!pw) {
+    logout();
     return resp;
   }
+
   const headers = { ...(options.headers || {}), "X-Reauth-Password": pw };
   resp = await fetch(url, { ...options, headers });
+  if (resp.status === 401) {
+    logout();
+  }
   return resp;
 }


### PR DESCRIPTION
## Summary
- logout user if reauthentication prompt is cancelled or fails
- document new logout behavior in README

## Testing
- `python3 -m venv .venv && source .venv/bin/activate && pip install -q -r backend/requirements.txt && cd backend && PYTHONPATH=. pytest -q > ../pytest.log && cd .. && deactivate`
- `tail -n 20 pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68757107260c832eb24393749fb519e1