### PR TITLE
Fix duplicate logout in api.js

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -6,11 +6,6 @@ export function logout() {
   window.location.reload();
 }
 
-export function logout() {
-  localStorage.removeItem("token");
-  window.location.reload();
-}
-
 export async function apiFetch(path, options = {}) {
   const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
   const headers = { ...(options.headers || {}) };


### PR DESCRIPTION
## Summary
- remove duplicate `logout` function in `frontend/src/api.js`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68768909bee8832e85e1c0d2638cb339