### PR TITLE
Add API metrics and cart retrieval

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -56,6 +56,20 @@ async function purchase() {
   loadProducts();
 }
 
+async function viewStats() {
+  try {
+    const data = await fetchJSON(`${API_BASE}/api-calls`, {
+      headers: { 'X-Reauth-Password': password }
+    });
+    const list = Object.entries(data)
+      .map(([user, count]) => `<li>${user}: ${count}</li>`)
+      .join('');
+    setContent(`<h2>API Calls</h2><ul class="stats-list">${list}</ul>`);
+  } catch (e) {
+    alert('Failed to load stats');
+  }
+}
+
 function showLogin() {
   setContent(`
     <h2>Login</h2>
@@ -135,6 +149,7 @@ document.getElementById('homeBtn').addEventListener('click', loadProducts);
 document.getElementById('cartBtn').addEventListener('click', viewCart);
 document.getElementById('loginBtn').addEventListener('click', showLogin);
 document.getElementById('logoutBtn').addEventListener('click', logout);
+document.getElementById('statsBtn').addEventListener('click', viewStats);
 
 loadProducts();
 updateCartCount();

--- a/shop-ui/index.html
+++ b/shop-ui/index.html
@@ -12,6 +12,7 @@
         <nav>
             <button id="homeBtn">Home</button>
             <button id="cartBtn">Cart (<span id="cartCount">0</span>)</button>
+            <button id="statsBtn">API Calls</button>
             <span id="authSection">
                 <button id="loginBtn">Login</button>
                 <button id="logoutBtn" style="display:none">Logout</button>

--- a/shop-ui/style.css
+++ b/shop-ui/style.css
@@ -31,3 +31,12 @@ nav button {
     list-style: none;
     padding: 0;
 }
+
+.stats-list {
+    list-style: none;
+    padding: 0;
+}
+
+.stats-list li {
+    margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- integrate demo shop with APIShield+ by storing login token
- expose /api-calls route that returns API usage stats
- show API call counts in demo shop UI
- style stats list
- update credential stuffing script to capture cart contents

## Testing
- `PYTHONPATH=backend pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876ae4875e8832ebf20ab4bff210710