### PR TITLE
Serve demo shop UI automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ npm start
 
 The API will be available on <http://localhost:3005> by default.
 
-To try the browser-based UI, open `shop-ui/index.html` after starting the server.
+The shop UI is now served directly by the Node server, so simply browse to
+<http://localhost:3005/> after starting it.
 
 ## Credential Stuffing Simulation
 

--- a/demo-shop/README.md
+++ b/demo-shop/README.md
@@ -13,6 +13,10 @@ npm install
 node server.js
 ```
 
+With the server running you can simply open `http://localhost:3005/` in your
+browser to view the demo shop UI. The static files are served from the
+`shop-ui` directory automatically so no additional web server is required.
+
 The service listens on port `3005` by default and exposes simple JSON endpoints:
 
 - `POST /register` – create an account

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const session = require('express-session');
 const bodyParser = require('body-parser');
 const axios = require('axios');
+const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3005;
@@ -13,6 +14,9 @@ app.use(session({
   resave: false,
   saveUninitialized: true
 }));
+
+// Serve the static front-end so visiting '/' shows the shop UI
+app.use(express.static(path.join(__dirname, '../shop-ui')));
 
 const products = [
   { id: 1, name: 'Demo Socks', price: 10 },


### PR DESCRIPTION
## Summary
- serve the `shop-ui` static files from the demo-shop server
- document the new behavior in both READMEs

## Testing
- `pytest -q`
- `npm install && npm start`

------
https://chatgpt.com/codex/tasks/task_e_6876bc0a0d10832ea97dc11ac1259af7