### PR TITLE
Fix pytest import path

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Ensure the backend package is on the Python path so tests can import app.*
+backend_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(backend_root))


### PR DESCRIPTION
## Summary
- add `backend/tests/conftest.py` to set Python path for test discovery

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68770c9154e4832ea411a39ac79a4e0c