### PR TITLE
Run tests and fix style issues

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -15,22 +15,27 @@ if not getattr(settings, "SECRET_KEY", None):
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return pwd_context.verify(plain_password, hashed_password)
 
 def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
+
 def create_access_token(
     data: dict[str, Any],
     expires_delta: Union[timedelta, None] = None
 ) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES))
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
     to_encode.update({"exp": expire})
     token = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
     logging.info("Issued token for %s: %s", data.get("sub"), token)
     return token
+
 
 def decode_access_token(token: str) -> dict[str, Any]:
     try:

--- a/backend/app/crud/alerts.py
+++ b/backend/app/crud/alerts.py
@@ -2,5 +2,6 @@
 from sqlalchemy.orm import Session
 from app.models.alerts import Alert
 
+
 def get_all_alerts(db: Session) -> list[Alert]:
     return db.query(Alert).all()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,9 +50,10 @@ app.include_router(alerts_router)   # your /api/alerts endpoint
 app.include_router(auth_router)     # /register, /login, /api/token
 app.include_router(config_router)   # /config
 app.include_router(security_router) # /api/security
-app.include_router(user_stats_router) # /api/user-calls
+app.include_router(user_stats_router)  # /api/user-calls
 app.include_router(events_router)   # /api/events
-app.include_router(last_logins_router) # /api/last-logins
+app.include_router(last_logins_router)  # /api/last-logins
+
 
 @app.get("/ping")
 def ping():

--- a/backend/app/models/events.py
+++ b/backend/app/models/events.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from sqlalchemy import Column, Integer, String, Boolean, DateTime
 from app.core.db import Base
 
+
 class Event(Base):
     __tablename__ = "events"
 

--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, Integer, String
 from app.core.db import Base
 
+
 class User(Base):
     __tablename__ = "users"
 

--- a/backend/app/schemas/alerts.py
+++ b/backend/app/schemas/alerts.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from datetime import datetime
 from typing import Optional
 
+
 class AlertRead(BaseModel):
     id: int
     ip_address: str

--- a/backend/app/schemas/events.py
+++ b/backend/app/schemas/events.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel
 
+
 class EventRead(BaseModel):
     id: int
     username: Optional[str]

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel
 
+
 class UserCreate(BaseModel):
     username: str
     password: str
     role: str | None = None
+
 
 class UserRead(BaseModel):
     id: int

--- a/backend/check_alerts_rows.py
+++ b/backend/check_alerts_rows.py
@@ -7,7 +7,10 @@ cursor = conn.cursor()
 
 print("Current alerts:")
 print("ID | IP Address | Total Fails | Detail | Timestamp")
-for row in cursor.execute("SELECT id, ip_address, total_fails, detail, timestamp FROM alerts ORDER BY timestamp DESC"):
+for row in cursor.execute(
+    "SELECT id, ip_address, total_fails, detail, timestamp "
+    "FROM alerts ORDER BY timestamp DESC"
+):
     print(f"{row[0]} | {row[1]} | {row[2]} | {row[3]} | {row[4]}")
 
 conn.close()

--- a/backend/check_alerts_table.py
+++ b/backend/check_alerts_table.py
@@ -12,4 +12,3 @@ for row in rows:
     print(" | ".join(str(item) for item in row))
 
 conn.close()
-

--- a/backend/tests/test_anomaly.py
+++ b/backend/tests/test_anomaly.py
@@ -4,9 +4,9 @@ import importlib
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from fastapi.testclient import TestClient
-import app.main as main_module
-from app.core.db import Base, engine, SessionLocal
+from fastapi.testclient import TestClient  # noqa: E402
+import app.main as main_module  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
 
 client = None
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -5,11 +5,11 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from datetime import timedelta
 
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.db import Base, engine, SessionLocal
-from app.core.config import settings
-import app.api.auth as auth_module
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.config import settings  # noqa: E402
+import app.api.auth as auth_module  # noqa: E402
 
 client = TestClient(app)
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -3,11 +3,11 @@ import os
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.db import SessionLocal, Base, engine
-from app.core.security import get_password_hash
-from app.crud.users import create_user
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import SessionLocal, Base, engine  # noqa: E402
+from app.core.security import get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
 
 client = TestClient(app)
 
@@ -23,8 +23,6 @@ def _auth_headers():
     resp = client.post("/login", json={"username": "admin", "password": "pw"})
     token = resp.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
-
-
 
 
 def test_config_default():

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -3,19 +3,21 @@ import os
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.db import Base, engine, SessionLocal
-from app.core.security import get_password_hash
-from app.crud.users import create_user
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.security import get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
 
 client = TestClient(app)
+
 
 def setup_function(_):
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username='alice', password_hash=get_password_hash('pw'))
+
 
 def teardown_function(_):
     SessionLocal().close()

--- a/backend/tests/test_last_logins.py
+++ b/backend/tests/test_last_logins.py
@@ -1,14 +1,12 @@
 import os
-from datetime import datetime
-
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.db import Base, engine, SessionLocal
-from app.core.security import create_access_token, get_password_hash
-from app.crud.users import create_user
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.security import create_access_token, get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
 
 client = TestClient(app)
 

--- a/backend/tests/test_reauth.py
+++ b/backend/tests/test_reauth.py
@@ -1,10 +1,9 @@
 import importlib
-import os
 
-from fastapi.testclient import TestClient
-from app.core.db import Base, engine, SessionLocal
-from app.core.security import get_password_hash
-from app.crud.users import create_user
+from fastapi.testclient import TestClient  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.security import get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
 
 
 def _reload_app():
@@ -30,7 +29,12 @@ def test_missing_password_header(monkeypatch):
     monkeypatch.setenv("REAUTH_PER_REQUEST", "true")
     client = _reload_app()
 
-    token = client.post("/login", json={"username": "alice", "password": "pw"}).json()["access_token"]
+    token = (
+        client.post(
+            "/login",
+            json={"username": "alice", "password": "pw"},
+        ).json()["access_token"]
+    )
     resp = client.get("/api/me", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Password required"
@@ -43,7 +47,12 @@ def test_reauth_success(monkeypatch):
     monkeypatch.setenv("REAUTH_PER_REQUEST", "true")
     client = _reload_app()
 
-    token = client.post("/login", json={"username": "alice", "password": "pw"}).json()["access_token"]
+    token = (
+        client.post(
+            "/login",
+            json={"username": "alice", "password": "pw"},
+        ).json()["access_token"]
+    )
     headers = {"Authorization": f"Bearer {token}", "X-Reauth-Password": "pw"}
     resp = client.get("/api/me", headers=headers)
     assert resp.status_code == 200
@@ -51,4 +60,3 @@ def test_reauth_success(monkeypatch):
 
     monkeypatch.setenv("REAUTH_PER_REQUEST", "false")
     _reload_app()
-

--- a/backend/tests/test_score.py
+++ b/backend/tests/test_score.py
@@ -5,14 +5,15 @@ from datetime import datetime, timedelta
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.db import Base, engine, SessionLocal
-from app.models.alerts import Alert
-from app.crud.users import create_user
-from app.core.security import get_password_hash
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.models.alerts import Alert  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
+from app.core.security import get_password_hash  # noqa: E402
 
 client = TestClient(app)
+
 
 def _auth_headers():
     resp = client.post('/login', json={'username': 'admin', 'password': 'pw'})

--- a/backend/tests/test_security_toggle.py
+++ b/backend/tests/test_security_toggle.py
@@ -4,12 +4,11 @@ import os
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.db import Base, engine, SessionLocal
-from app.api.security import SECURITY_ENABLED
-from app.crud.users import create_user
-from app.core.security import get_password_hash
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
+from app.core.security import get_password_hash  # noqa: E402
 
 client = TestClient(app)
 

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -4,14 +4,15 @@ from datetime import datetime
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.db import Base, engine, SessionLocal
-from app.models.alerts import Alert
-from app.core.security import create_access_token, get_password_hash
-from app.crud.users import create_user
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.models.alerts import Alert  # noqa: E402
+from app.core.security import create_access_token, get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
 
 client = TestClient(app)
+
 
 def setup_function(_):
     Base.metadata.drop_all(bind=engine)
@@ -26,8 +27,22 @@ def test_stats_endpoint():
     token = create_access_token({"sub": "user"})
     with SessionLocal() as db:
         create_user(db, username='user', password_hash=get_password_hash('pw'))
-        db.add(Alert(ip_address='1.1.1.1', total_fails=1, detail='Failed login', timestamp=datetime(2023,1,1,0,0,0)))
-        db.add(Alert(ip_address='1.1.1.1', total_fails=2, detail='Blocked: too many failures', timestamp=datetime(2023,1,1,0,1,0)))
+        db.add(
+            Alert(
+                ip_address='1.1.1.1',
+                total_fails=1,
+                detail='Failed login',
+                timestamp=datetime(2023, 1, 1, 0, 0, 0),
+            )
+        )
+        db.add(
+            Alert(
+                ip_address='1.1.1.1',
+                total_fails=2,
+                detail='Blocked: too many failures',
+                timestamp=datetime(2023, 1, 1, 0, 1, 0),
+            )
+        )
         db.commit()
 
     resp = client.get('/api/alerts/stats', headers={'Authorization': f'Bearer {token}'})

--- a/backend/tests/test_user_calls.py
+++ b/backend/tests/test_user_calls.py
@@ -3,11 +3,11 @@ import os
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from fastapi.testclient import TestClient
-from app.main import app
-from app.core.db import Base, engine, SessionLocal
-from app.core.security import create_access_token, get_password_hash
-from app.crud.users import create_user
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.security import create_access_token, get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
 
 client = TestClient(app)
 

--- a/backend/tests/test_zero_trust.py
+++ b/backend/tests/test_zero_trust.py
@@ -2,13 +2,13 @@ import os
 
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
-from fastapi.testclient import TestClient
-import importlib
-import app.core.zero_trust as zero_trust
-import app.main as main_module
-from app.core.db import Base, engine, SessionLocal
-from app.crud.users import create_user
-from app.core.security import get_password_hash
+from fastapi.testclient import TestClient  # noqa: E402
+import importlib  # noqa: E402
+import app.core.zero_trust as zero_trust  # noqa: E402
+import app.main as main_module  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
+from app.core.security import get_password_hash  # noqa: E402
 
 # Client will be initialised in setup_function after reloading the app
 client = None
@@ -57,4 +57,3 @@ def test_invalid_key_records_score():
     with SessionLocal() as db:
         from app.models.alerts import Alert
         assert db.query(Alert).count() == 1
-

--- a/scripts/perf_test.py
+++ b/scripts/perf_test.py
@@ -5,6 +5,7 @@ import time
 
 import httpx
 
+
 async def worker(client, url, payload, semaphore, results):
     async with semaphore:
         start = time.perf_counter()
@@ -13,12 +14,18 @@ async def worker(client, url, payload, semaphore, results):
         results.append(latency)
         resp.raise_for_status()
 
+
 async def run(url: str, concurrency: int, total: int):
     payload = {"client_ip": "127.0.0.1", "auth_result": "success"}
     semaphore = asyncio.Semaphore(concurrency)
     results: list[float] = []
     async with httpx.AsyncClient() as client:
-        tasks = [asyncio.create_task(worker(client, url, payload, semaphore, results)) for _ in range(total)]
+        tasks = [
+            asyncio.create_task(
+                worker(client, url, payload, semaphore, results)
+            )
+            for _ in range(total)
+        ]
         await asyncio.gather(*tasks)
     avg = sum(results) / len(results)
     print(f"Sent {len(results)} requests")

--- a/scripts/reauth_client.py
+++ b/scripts/reauth_client.py
@@ -51,7 +51,8 @@ def main() -> None:
             "Steps:\n"
             "  1. Replace 'alice' with your own username.\n"
             "  2. When 'Password:' appears, type the password you used at registration.\n"
-            "  3. For each request you will be asked for 'Re-auth password:' -- type the same password again.\n"
+            "  3. For each request you will be asked for 'Re-auth password:' "
+            "-- type the same password again.\n"
             "  Press Ctrl+C to stop the program at any time."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/scripts/stuffing.py
+++ b/scripts/stuffing.py
@@ -140,7 +140,11 @@ if __name__ == "__main__":
     parser.add_argument("--jwt", action="store_true", help="Use JWT login endpoint")
     parser.add_argument("--rate", type=float, default=5, help="Attempts per second")
     parser.add_argument("--attempts", type=int, default=50, help="Number of attempts to send")
-    parser.add_argument("--score-base", default="http://localhost:8001", help="Detector API base URL")
+    parser.add_argument(
+        "--score-base",
+        default="http://localhost:8001",
+        help="Detector API base URL",
+    )
     parser.add_argument("--shop-url", default="http://localhost:3005", help="Demo shop base URL")
     args = parser.parse_args()
     attack(

--- a/sdn-controller/simple_monitor.py
+++ b/sdn-controller/simple_monitor.py
@@ -54,4 +54,3 @@ class SimpleMonitor13(app_manager.RyuApp):
                 "flow match=%s packets=%d bytes=%d",
                 stat.match, stat.packet_count, stat.byte_count,
             )
-


### PR DESCRIPTION
## Summary
- improve code style in backend modules and scripts
- split long lines for readability
- adjust test helpers for flake8
- fix minor issues in helper scripts and SDN controller

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68779e5ee634832e993b95c9cecd4d18