### PR TITLE
Fix user role migration

### DIFF
--- a/backend/alembic/versions/ccccc_add_role_to_users_table.py
+++ b/backend/alembic/versions/ccccc_add_role_to_users_table.py
@@ -16,8 +16,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column('users', sa.Column('role', sa.String(), nullable=False, server_default='user'))
-    op.alter_column('users', 'role', server_default=None)
+    op.add_column(
+        "users",
+        sa.Column("role", sa.String(), nullable=False, server_default="user"),
+    )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
- remove a stray `alter_column` call from `add_role_to_users_table` migration
- verify `alembic upgrade head` works

## Testing
- `alembic upgrade head`

------
https://chatgpt.com/codex/tasks/task_e_68780b957978832eb5071e7a8027f8b6