### PR TITLE
Toggle per-request reauth off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ DEMO_SHOP_PATH=./demo-shop
 # Enable ML-based anomaly checks
 ANOMALY_DETECTION=true
 # Require password on every API request
-REAUTH_PER_REQUEST=true
+REAUTH_PER_REQUEST=false
 # Require X-API-Key header on every request
 ZERO_TRUST_API_KEY=demo-key
 ```

--- a/demo-shop/README.md
+++ b/demo-shop/README.md
@@ -3,10 +3,8 @@
 This directory contains a very small Node.js-based e-commerce example used in place of the previous shop demo.
 It can integrate with the APIShield+ backend for additional telemetry. By default
 this forwarding is **disabled** so the shop can run standalone without errors.
-Set the environment variable `FORWARD_API=true` to enable calls to the backend.
-Requests to the API use a short timeout controlled by `API_TIMEOUT_MS` (default `2000`).
-Each protected endpoint checks the `X-Reauth-Password` header to require the
-user's password on every request.
+Set the environment variable `FORWARD_API=true` to enable calls to the backend. Requests to the API use a short timeout controlled by `API_TIMEOUT_MS` (default `2000`). Set `REAUTH_PER_REQUEST=true` if you want the shop to require the password on every request.
+Each protected endpoint checks the `X-Reauth-Password` header only when this option is enabled, and it is disabled by default so the shop behaves like a normal session-based app.
 
 The server pre-registers a demo account so you can log in immediately with
 `alice`/`secret`.
@@ -29,8 +27,11 @@ The service listens on port `3005` by default and exposes simple JSON endpoints:
 - `POST /login` – log in and begin a session
 - `POST /logout` – log out
 - `GET /products` – list products
-- `POST /cart` – add a product to the cart (requires `X-Reauth-Password`)
-- `GET /cart` – view the cart (requires `X-Reauth-Password`)
-- `POST /purchase` – clear the cart (requires `X-Reauth-Password`)
+- `POST /cart` – add a product to the cart (requires `X-Reauth-Password` when
+  `REAUTH_PER_REQUEST=true`)
+- `GET /cart` – view the cart (requires `X-Reauth-Password` when
+  `REAUTH_PER_REQUEST=true`)
+- `POST /purchase` – clear the cart (requires `X-Reauth-Password` when
+  `REAUTH_PER_REQUEST=true`)
 
 Set `API_BASE` to point at the running APIShield+ backend if it isn't at `http://localhost:8001`.

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -12,6 +12,7 @@ const API_TIMEOUT = parseInt(process.env.API_TIMEOUT_MS || '2000', 10);
 // Disable integration with the APIShield backend unless explicitly enabled.
 // Most demos run the shop standalone so suppress the noisy API errors by default.
 const FORWARD_API = process.env.FORWARD_API === 'true';
+const REAUTH_PER_REQUEST = process.env.REAUTH_PER_REQUEST === 'true';
 
 app.use(bodyParser.json());
 app.use(session({
@@ -50,9 +51,11 @@ function requireAuth(req, res, next) {
   if (!req.session.username) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  const pw = req.get('X-Reauth-Password');
-  if (!pw || pw !== req.session.password) {
-    return res.status(401).json({ error: 'Reauthentication failed' });
+  if (REAUTH_PER_REQUEST) {
+    const pw = req.get('X-Reauth-Password');
+    if (!pw || pw !== req.session.password) {
+      return res.status(401).json({ error: 'Reauthentication failed' });
+    }
   }
   next();
 }


### PR DESCRIPTION
## Summary
- add `REAUTH_PER_REQUEST` toggle to demo shop server
- document the new option and set default to `false` in README files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879b4f74264832ea66181cc94360bcd