### PR TITLE
Fix login prompt handling in demo shop

### DIFF
--- a/shop-ui/README.md
+++ b/shop-ui/README.md
@@ -10,4 +10,4 @@ npm install
 node server.js
 ```
 
-The UI communicates with the API on `http://localhost:3005`. You can browse products, register and log in, add items to your cart, and simulate a purchase. Each protected action includes the password in the `X-Reauth-Password` header so the backend can validate the session on every request.
+The UI communicates with the API on `http://localhost:3005`. You can browse products, register and log in, add items to your cart, and simulate a purchase. Each protected action includes the password in the `X-Reauth-Password` header so the backend can validate the session on every request. If a protected call is denied (HTTP 401), the UI now logs you out automatically so the login button becomes available again.

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -16,6 +16,12 @@ async function fetchJSON(url, options = {}) {
     fetchOpts.headers['X-Reauth-Password'] = pw;
   }
   const res = await fetch(url, fetchOpts);
+  if (res.status === 401) {
+    try {
+      await logout();
+    } catch {}
+    throw new Error('Unauthorized');
+  }
   if (!res.ok) throw new Error(`Request failed: ${res.status}`);
   return res.json();
 }


### PR DESCRIPTION
## Summary
- automatically log out when reauth fails
- document new logout behaviour in demo shop UI

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a97acd120832e8a299776ddad2f89