### PR TITLE
Add access log tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ detection logic, and another toggles SQLAlchemy debug logging:
 - `ZERO_TRUST_API_KEY` – if set, every request must include this value in the
   `X-API-Key` header. Invalid keys are logged via `/score` and show up in
   Prometheus metrics.
+- All API calls are recorded. Retrieve them via `/api/access-logs`. Non-admin
+  users only see their own history.
 
 When enabled, clients must supply the password again via the
 `X-Reauth-Password` header. The dashboard automatically prompts for

--- a/backend/alembic/versions/eeeee_create_access_logs_table.py
+++ b/backend/alembic/versions/eeeee_create_access_logs_table.py
@@ -1,0 +1,32 @@
+"""create access logs table
+
+Revision ID: eeeee
+Revises: ddddd
+Create Date: 2025-07-05 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'eeeee'
+down_revision: Union[str, None] = 'ddddd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'access_logs',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('username', sa.String(), nullable=True),
+        sa.Column('path', sa.String(), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), nullable=False),
+    )
+    op.create_index(op.f('ix_access_logs_id'), 'access_logs', ['id'], unique=False)
+    op.create_index(op.f('ix_access_logs_username'), 'access_logs', ['username'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_access_logs_username'), table_name='access_logs')
+    op.drop_index(op.f('ix_access_logs_id'), table_name='access_logs')
+    op.drop_table('access_logs')

--- a/backend/app/api/access_logs.py
+++ b/backend/app/api/access_logs.py
@@ -1,0 +1,22 @@
+from typing import List, Optional
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.db import get_db
+from app.crud.access_logs import get_access_logs
+from app.schemas.access_logs import AccessLogRead
+from app.api.dependencies import get_current_user
+
+router = APIRouter(prefix="/api/access-logs", tags=["logs"])
+
+
+@router.get("/", response_model=List[AccessLogRead])
+def read_access_logs(
+    username: Optional[str] = None,
+    hours: Optional[int] = None,
+    db: Session = Depends(get_db),
+    current_user = Depends(get_current_user),
+):
+    if getattr(current_user, "role", None) != "admin":
+        username = getattr(current_user, "username", None)
+    return get_access_logs(db, username=username, hours=hours)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -74,7 +74,7 @@ def login(user_in: UserCreate, db: Session = Depends(get_db)):
                 timeout=3,
             )
         except Exception:
-            pass
+            log_event(db, user.username, "shop_login_error", False)
 
     return {"access_token": token, "token_type": "bearer"}
 

--- a/backend/app/core/access_log.py
+++ b/backend/app/core/access_log.py
@@ -1,0 +1,25 @@
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.core.security import decode_access_token
+from app.core.db import SessionLocal
+from app.crud.access_logs import create_access_log
+
+
+class AccessLogMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        try:
+            response = await call_next(request)
+            return response
+        finally:
+            username = None
+            auth = request.headers.get("Authorization")
+            if auth and auth.startswith("Bearer "):
+                token = auth.split()[1]
+                try:
+                    payload = decode_access_token(token)
+                    username = payload.get("sub")
+                except Exception:
+                    username = None
+            with SessionLocal() as db:
+                create_access_log(db, username, request.url.path)

--- a/backend/app/crud/access_logs.py
+++ b/backend/app/crud/access_logs.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta
+from sqlalchemy.orm import Session
+from app.models.access_logs import AccessLog
+
+
+def create_access_log(db: Session, username: str | None, path: str) -> AccessLog:
+    log = AccessLog(username=username, path=path)
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return log
+
+
+def get_access_logs(
+    db: Session, username: str | None = None, hours: int | None = None
+) -> list[AccessLog]:
+    query = db.query(AccessLog)
+    if username is not None:
+        query = query.filter(AccessLog.username == username)
+    if hours is not None:
+        since = datetime.utcnow() - timedelta(hours=hours)
+        query = query.filter(AccessLog.timestamp >= since)
+    return query.order_by(AccessLog.timestamp.desc()).all()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 from app.core.zero_trust import ZeroTrustMiddleware
 from app.core.logging import APILoggingMiddleware
+from app.core.access_log import AccessLogMiddleware
 from app.core.anomaly import AnomalyDetectionMiddleware
 from app.core.policy import PolicyEngineMiddleware
 from app.core.metrics import MetricsMiddleware
@@ -19,6 +20,7 @@ from app.api.security import router as security_router
 from app.api.user_stats import router as user_stats_router
 from app.api.events import router as events_router
 from app.api.last_logins import router as last_logins_router
+from app.api.access_logs import router as access_logs_router
 
 app = FastAPI(title="APIShield+")
 
@@ -34,6 +36,7 @@ app.add_middleware(
 # Log incoming requests and any presented Authorization headers
 app.add_middleware(APILoggingMiddleware)
 app.add_middleware(MetricsMiddleware)
+app.add_middleware(AccessLogMiddleware)
 
 # Enforce Zero Trust API key if configured
 app.add_middleware(ZeroTrustMiddleware)
@@ -53,6 +56,7 @@ app.include_router(security_router) # /api/security
 app.include_router(user_stats_router)  # /api/user-calls
 app.include_router(events_router)   # /api/events
 app.include_router(last_logins_router)  # /api/last-logins
+app.include_router(access_logs_router)  # /api/access-logs
 
 
 @app.get("/ping")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from .alerts import Alert
 from .users import User
 from .events import Event
+from .access_logs import AccessLog
 
-__all__ = ["Alert", "User", "Event"]
+__all__ = ["Alert", "User", "Event", "AccessLog"]

--- a/backend/app/models/access_logs.py
+++ b/backend/app/models/access_logs.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime
+from app.core.db import Base
+
+class AccessLog(Base):
+    __tablename__ = "access_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, nullable=True, index=True)
+    path = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/app/schemas/access_logs.py
+++ b/backend/app/schemas/access_logs.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class AccessLogRead(BaseModel):
+    id: int
+    username: str | None = None
+    path: str
+    timestamp: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/tests/test_access_logs.py
+++ b/backend/tests/test_access_logs.py
@@ -1,0 +1,36 @@
+import os
+
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+os.environ['SECRET_KEY'] = 'test-secret'
+
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.security import create_access_token, get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_function(_):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    with SessionLocal() as db:
+        create_user(db, username='alice', password_hash=get_password_hash('pw'))
+
+
+def teardown_function(_):
+    SessionLocal().close()
+
+
+def test_access_logs_recorded():
+    token = create_access_token({'sub': 'alice'})
+    headers = {'Authorization': f'Bearer {token}'}
+
+    client.get('/ping', headers=headers)
+
+    resp = client.get('/api/access-logs', headers=headers)
+    assert resp.status_code == 200
+    logs = resp.json()
+    assert any(l['path'] == '/ping' for l in logs)
+    assert all(l['username'] == 'alice' for l in logs)


### PR DESCRIPTION
## Summary
- log failures when forwarding login to Demo Shop
- create an access logs table and middleware
- expose new `/api/access-logs` endpoint
- document access logs in the README
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687abb81e1d8832eaac040e4f700cf8b