### PR TITLE
Update env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ strictly prohibited. The RockYou‑derived password list included under
 
 The backend reads environment variables from a `.env` file on startup. The
 `SECRET_KEY` must be set; otherwise `backend/app/core/security.py` raises an
-error during import. Two optional variables control the credential stuffing
-detection logic, and another toggles SQLAlchemy debug logging:
+error during import. Several optional variables control features such as
+credential stuffing thresholds, debug logging, forwarding to the Demo Shop,
+anomaly detection, and enforcing a zero‑trust API key:
 
 - `FAIL_LIMIT` – how many failures are allowed within the window before
   blocking a client (default `5`).


### PR DESCRIPTION
## Summary
- adjust README to remove mention of *two* optional variables
- briefly summarize that multiple environment variables control features like logging, demo shop forwarding, anomaly detection and zero‑trust keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac6637688832e9a68877f2b5ec0d6