### PR TITLE
Fix infinite password prompt when reauth is enabled

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -180,6 +180,10 @@ async function logout() {
 }
 
 async function updateCartCount() {
+  if (!username) {
+    document.getElementById('cartCount').textContent = 0;
+    return;
+  }
   try {
     const items = await fetchJSON(`${API_BASE}/cart`);
     document.getElementById('cartCount').textContent = items.length;


### PR DESCRIPTION
## Summary
- avoid repeated logout loops by checking `username` before fetching the cart

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bba229c3c832ea9fe0b9ae8bd8819