### PR TITLE
Add JWT viewer and API endpoint demo

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,8 @@ import LoginForm from "./LoginForm";
 import AttackSim from "./AttackSim";
 import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
+import JwtViewer from "./JwtViewer";
+import EndpointDemo from "./EndpointDemo";
 import "./App.css";
 
 function App() {
@@ -30,6 +32,8 @@ function App() {
       <h1 className="dashboard-header">APIShield+ Dashboard</h1>
       <UserAccounts onSelect={setSelectedUser} />
       <LoginStatus token={token} />
+      <JwtViewer token={token} />
+      <EndpointDemo token={token} />
       <ScoreForm onNewAlert={() => setRefreshKey(k => k + 1)} />
       <AlertsChart token={token} />
       <AlertsTable refresh={refreshKey} token={token} />

--- a/frontend/src/EndpointDemo.jsx
+++ b/frontend/src/EndpointDemo.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import { apiFetch, API_BASE } from "./api";
+
+export default function EndpointDemo({ token }) {
+  const [protectedData, setProtectedData] = useState("Not fetched");
+  const [unprotectedData, setUnprotectedData] = useState("Not fetched");
+  const [msg, setMsg] = useState("");
+
+  const fetchProtected = async () => {
+    setMsg("");
+    try {
+      const resp = await apiFetch("/api/me", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!resp.ok) throw new Error(await resp.text());
+      const data = await resp.json();
+      setProtectedData(JSON.stringify(data));
+      setMsg("Fetched protected data");
+    } catch (err) {
+      setMsg(err.message);
+      setProtectedData("Error");
+    }
+  };
+
+  const fetchUnprotected = async () => {
+    setMsg("");
+    try {
+      const resp = await fetch(`${API_BASE}/ping`);
+      const data = await resp.json();
+      setUnprotectedData(JSON.stringify(data));
+      setMsg("Fetched unprotected data");
+    } catch (err) {
+      setMsg(err.message);
+      setUnprotectedData("Error");
+    }
+  };
+
+  return (
+    <div style={{ marginTop: "1rem" }}>
+      <h3>API Endpoint Demo</h3>
+      <button onClick={fetchProtected} disabled={!token}>Fetch Protected</button>
+      <button onClick={fetchUnprotected} style={{ marginLeft: "0.5rem" }}>Fetch Unprotected</button>
+      {msg && <p>{msg}</p>}
+      <div style={{ display: "flex", gap: "1rem" }}>
+        <div>
+          <h4>Protected Data</h4>
+          <pre>{protectedData}</pre>
+        </div>
+        <div>
+          <h4>Unprotected Data</h4>
+          <pre>{unprotectedData}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/JwtViewer.jsx
+++ b/frontend/src/JwtViewer.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+function decode(token) {
+  if (!token) return null;
+  try {
+    const [header, payload] = token.split(".");
+    return {
+      header: JSON.parse(atob(header)),
+      payload: JSON.parse(atob(payload)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export default function JwtViewer({ token }) {
+  const decoded = decode(token);
+  if (!decoded) return null;
+
+  const copy = () => {
+    navigator.clipboard.writeText(token).catch(() => {});
+  };
+
+  return (
+    <div style={{ marginTop: "1rem" }}>
+      <h3>JWT Details</h3>
+      <pre style={{ wordBreak: "break-all", background: "#f3f3f3", padding: "0.5rem" }}>{token}</pre>
+      <button onClick={copy}>Copy JWT</button>
+      <div style={{ display: "flex", gap: "1rem", marginTop: "0.5rem" }}>
+        <div>
+          <h4>Header</h4>
+          <pre>{JSON.stringify(decoded.header, null, 2)}</pre>
+        </div>
+        <div>
+          <h4>Payload</h4>
+          <pre>{JSON.stringify(decoded.payload, null, 2)}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -4,6 +4,7 @@ import { apiFetch } from "./api";
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState(null);
 
   const handleSubmit = async e => {
@@ -32,7 +33,18 @@ export default function LoginForm({ onLogin }) {
       </label>
       <label>
         Password:
-        <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+        <input
+          type={showPassword ? "text" : "password"}
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={() => setShowPassword(sp => !sp)}
+          style={{ marginLeft: "0.5rem" }}
+        >
+          {showPassword ? "Hide" : "Show"}
+        </button>
       </label>
       <button type="submit">Login</button>
       {error && <p style={{ color: "red" }}>{error}</p>}


### PR DESCRIPTION
## Summary
- allow showing/hiding password in login form
- add `JwtViewer` component for inspecting tokens
- add `EndpointDemo` component to demonstrate protected vs unprotected API calls
- display new components in `App.js`

## Testing
- `npm test -- --watchAll=false`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6881808c840c832e811f2f06a5ef14f7