### PR TITLE
Add metrics page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^19.1.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       },
@@ -2893,6 +2894,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -12928,6 +12938,38 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "react": "^19.1.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,22 +1,12 @@
 import { useState } from "react";
-import ScoreForm from "./ScoreForm";
-import AlertsTable from "./AlertsTable";
-import EventsTable from "./EventsTable";
-import ShopIframe from "./ShopIframe";
-import AlertsChart from "./AlertsChart";
-import SecurityToggle from "./SecurityToggle";
+import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import LoginForm from "./LoginForm";
-import AttackSim from "./AttackSim";
-import UserAccounts from "./UserAccounts";
-import LoginStatus from "./LoginStatus";
-import JwtViewer from "./JwtViewer";
-import EndpointDemo from "./EndpointDemo";
+import DashboardMain from "./DashboardMain";
+import MetricsPage from "./MetricsPage";
 import "./App.css";
 
 function App() {
-  const [refreshKey, setRefreshKey] = useState(0);
   const [token, setToken] = useState(localStorage.getItem("token"));
-  const [selectedUser, setSelectedUser] = useState("alice");
 
   if (!token) {
     return (
@@ -28,24 +18,17 @@ function App() {
   }
 
   return (
-    <div className="app-container">
-      <h1 className="dashboard-header">APIShield+ Dashboard</h1>
-      <UserAccounts onSelect={setSelectedUser} />
-      <LoginStatus token={token} />
-      <JwtViewer token={token} />
-      <EndpointDemo token={token} />
-      <ScoreForm onNewAlert={() => setRefreshKey(k => k + 1)} />
-      <AlertsChart token={token} />
-      <AlertsTable refresh={refreshKey} token={token} />
-      <EventsTable token={token} />
-      <ShopIframe />
-      <div className="attack-section">
-        <AttackSim user={selectedUser} />
-        <div className="security-box">
-          <SecurityToggle />
-        </div>
+    <Router>
+      <div className="app-container">
+        <nav className="nav-links">
+          <Link to="/">Dashboard</Link> | <Link to="/metrics">Metrics</Link>
+        </nav>
+        <Routes>
+          <Route path="/" element={<DashboardMain token={token} />} />
+          <Route path="/metrics" element={<MetricsPage />} />
+        </Routes>
       </div>
-    </div>
+    </Router>
   );
 }
 

--- a/frontend/src/DashboardMain.jsx
+++ b/frontend/src/DashboardMain.jsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import ScoreForm from "./ScoreForm";
+import AlertsTable from "./AlertsTable";
+import EventsTable from "./EventsTable";
+import ShopIframe from "./ShopIframe";
+import AlertsChart from "./AlertsChart";
+import SecurityToggle from "./SecurityToggle";
+import AttackSim from "./AttackSim";
+import UserAccounts from "./UserAccounts";
+import LoginStatus from "./LoginStatus";
+import JwtViewer from "./JwtViewer";
+import EndpointDemo from "./EndpointDemo";
+
+export default function DashboardMain({ token }) {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [selectedUser, setSelectedUser] = useState("alice");
+
+  return (
+    <div className="app-container">
+      <h1 className="dashboard-header">APIShield+ Dashboard</h1>
+      <UserAccounts onSelect={setSelectedUser} />
+      <LoginStatus token={token} />
+      <JwtViewer token={token} />
+      <EndpointDemo token={token} />
+      <ScoreForm onNewAlert={() => setRefreshKey(k => k + 1)} />
+      <AlertsChart token={token} />
+      <AlertsTable refresh={refreshKey} token={token} />
+      <EventsTable token={token} />
+      <ShopIframe />
+      <div className="attack-section">
+        <AttackSim user={selectedUser} />
+        <div className="security-box">
+          <SecurityToggle />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/MetricsPage.jsx
+++ b/frontend/src/MetricsPage.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { API_BASE } from "./api";
+
+function parseMetrics(text) {
+  const data = {};
+  text.split("\n").forEach(line => {
+    if (line.startsWith("api_cpu_percent")) {
+      data.cpu = parseFloat(line.split(" ")[1]);
+    } else if (line.startsWith("api_memory_bytes")) {
+      data.memory = parseFloat(line.split(" ")[1]);
+    } else if (line.startsWith("api_request_latency_milliseconds_sum")) {
+      data.latSum = parseFloat(line.split(" ")[1]);
+    } else if (line.startsWith("api_request_latency_milliseconds_count")) {
+      data.latCount = parseFloat(line.split(" ")[1]);
+    }
+  });
+  if (data.latSum && data.latCount) {
+    data.avgLatency = data.latSum / data.latCount;
+  }
+  return data;
+}
+
+export default function MetricsPage() {
+  const [metrics, setMetrics] = useState(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/metrics`)
+      .then(res => res.text())
+      .then(text => setMetrics(parseMetrics(text)))
+      .catch(err => console.error("Metrics fetch error", err));
+  }, []);
+
+  if (!metrics) {
+    return <p>Loading metrics...</p>;
+  }
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <h2>Performance Metrics</h2>
+      <p>CPU Usage: {metrics.cpu ?? "-"}%</p>
+      <p>Memory Usage: {metrics.memory ? Math.round(metrics.memory / 1024 / 1024) : "-"} MB</p>
+      {metrics.avgLatency && (
+        <p>Avg Request Latency: {metrics.avgLatency.toFixed(2)} ms</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- install react-router-dom
- add DashboardMain component for existing dashboard view
- add MetricsPage to display backend Prometheus metrics
- update App.js to provide routing between Dashboard and Metrics page

## Testing
- `CI=true npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f1a62df0832eb34ebc8c5324d931