### PR TITLE
Fix demo shop login and display user status

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -1,4 +1,4 @@
-const API_BASE = 'http://localhost:3005';
+const API_BASE = '';
 let username = null;
 
 function setContent(html) {
@@ -123,17 +123,21 @@ function showLogin() {
   `);
   document.getElementById('loginForm').addEventListener('submit', async e => {
     e.preventDefault();
-    username = document.getElementById('username').value;
+    const inputUser = document.getElementById('username').value;
     const pw = document.getElementById('pw').value;
     try {
       await fetchJSON(`${API_BASE}/login`, {
         method: 'POST',
-        body: JSON.stringify({ username, password: pw }),
+        body: JSON.stringify({ username: inputUser, password: pw }),
         noAuth: true
       });
+      username = inputUser;
       document.getElementById('loginBtn').style.display = 'none';
       document.getElementById('logoutBtn').style.display = 'inline-block';
-      updateCartCount();
+      const status = document.getElementById('userStatus');
+      status.textContent = `Logged in as ${username}`;
+      status.style.display = 'inline-block';
+      updateCartCount(true);
       loadProducts();
     } catch (e) {
       showMessage('Login failed', true);
@@ -175,17 +179,20 @@ async function logout() {
   username = null;
   document.getElementById('loginBtn').style.display = 'inline-block';
   document.getElementById('logoutBtn').style.display = 'none';
-  updateCartCount();
+  const status = document.getElementById('userStatus');
+  status.textContent = '';
+  status.style.display = 'none';
+  updateCartCount(true);
   loadProducts();
 }
 
-async function updateCartCount() {
+async function updateCartCount(skipAuth = false) {
   if (!username) {
     document.getElementById('cartCount').textContent = 0;
     return;
   }
   try {
-    const items = await fetchJSON(`${API_BASE}/cart`);
+    const items = await fetchJSON(`${API_BASE}/cart`, skipAuth ? { noAuth: true } : {});
     document.getElementById('cartCount').textContent = items.length;
   } catch {
     document.getElementById('cartCount').textContent = 0;

--- a/shop-ui/index.html
+++ b/shop-ui/index.html
@@ -19,7 +19,8 @@
                     <button class="btn btn-light me-2" id="contactBtn">Contact</button>
                     <button class="btn btn-light me-2" id="cartBtn">Cart (<span id="cartCount">0</span>)</button>
                     <button class="btn btn-light me-2" id="statsBtn">API Calls</button>
-                    <span id="authSection">
+                    <span id="authSection" class="d-flex align-items-center">
+                        <span id="userStatus" class="navbar-text text-white me-2" style="display:none"></span>
                         <button class="btn btn-success me-2" id="loginBtn">Login</button>
                         <button class="btn btn-danger me-2" id="logoutBtn" style="display:none">Logout</button>
                     </span>


### PR DESCRIPTION
## Summary
- Use relative API paths so login works regardless of host.
- Show current user in navbar and update on login/logout.
- Skip re-auth prompt immediately after logging in or out.

## Testing
- `npm test` *(fails: Missing script "test")*
- `curl -i -c cookie.txt -X POST http://localhost:3005/login -H 'Content-Type: application/json' -d '{"username":"alice","password":"secret"}'`
- `curl -i -b cookie.txt http://localhost:3005/cart`

------
https://chatgpt.com/codex/tasks/task_e_688e924971ac832ea89541a8fa8103cc