### PR TITLE
Add auto logout option to dashboard and backend

### DIFF
--- a/backend/app/core/re_auth.py
+++ b/backend/app/core/re_auth.py
@@ -60,6 +60,7 @@ class ReAuthMiddleware(BaseHTTPMiddleware):
                     False,
                     detail="Invalid credentials",
                     with_jwt=True,
+                    token=token,
                 )
                 log_event(db, username, "reauth", False)
                 return JSONResponse(

--- a/frontend/src/AutoLogoutToggle.jsx
+++ b/frontend/src/AutoLogoutToggle.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { apiFetch } from "./api";
+
+export default function AutoLogoutToggle() {
+  const [enabled, setEnabled] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadState = async () => {
+    try {
+      const resp = await apiFetch("/api/security");
+      if (resp.ok) {
+        const data = await resp.json();
+        setEnabled(data.logout_on_compromise);
+      } else {
+        throw new Error(await resp.text());
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  useEffect(() => {
+    loadState();
+  }, []);
+
+  const toggle = async () => {
+    try {
+      const resp = await apiFetch("/api/security", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ logout_on_compromise: !enabled })
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        setEnabled(data.logout_on_compromise);
+      } else {
+        throw new Error(await resp.text());
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="security-toggle">
+      <label>
+        <input type="checkbox" checked={enabled} onChange={toggle} /> Auto Logout on
+        Hack
+      </label>
+      {error && <p className="error-text">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/DashboardMain.jsx
+++ b/frontend/src/DashboardMain.jsx
@@ -5,6 +5,7 @@ import EventsTable from "./EventsTable";
 import ShopIframe from "./ShopIframe";
 import AlertsChart from "./AlertsChart";
 import SecurityToggle from "./SecurityToggle";
+import AutoLogoutToggle from "./AutoLogoutToggle";
 import AttackSim from "./AttackSim";
 import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
@@ -31,6 +32,7 @@ export default function DashboardMain({ token }) {
         <AttackSim user={selectedUser} />
         <div className="security-box">
           <SecurityToggle />
+          <AutoLogoutToggle />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- introduce `logout_on_compromise` flag in security API and revoke tokens on detected stuffing
- add dashboard toggle to control auto logout when accounts are compromised
- cover auto logout behavior with tests

## Testing
- `PYTHONPATH=. pytest`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688ec9ff25f4832ebab9523bd2933680