### PR TITLE
Add admin user management and security scoring

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import require_role
+from app.core.db import get_db
+from app.core.security import get_password_hash
+from app.core.account_security import calculate_security_score
+from app.crud.users import (
+    get_user_by_username,
+    create_user,
+    delete_user,
+)
+from app.schemas.users import UserCreate, UserRead
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.post("/users", response_model=UserRead, dependencies=[Depends(require_role("admin"))])
+def admin_create_user(user_in: UserCreate, db: Session = Depends(get_db)):
+    if get_user_by_username(db, user_in.username):
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed = get_password_hash(user_in.password)
+    score = calculate_security_score(
+        user_in.password,
+        two_factor=user_in.two_factor,
+        security_question=user_in.security_question,
+    )
+    role = user_in.role or "user"
+    user = create_user(
+        db,
+        username=user_in.username,
+        password_hash=hashed,
+        role=role,
+        security_score=score,
+    )
+    return user
+
+
+@router.delete("/users/{username}", dependencies=[Depends(require_role("admin"))])
+def admin_delete_user(username: str, db: Session = Depends(get_db)):
+    if not delete_user(db, username):
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"detail": "User deleted"}

--- a/backend/app/core/account_security.py
+++ b/backend/app/core/account_security.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def calculate_security_score(
+    password: str,
+    *,
+    two_factor: bool = False,
+    security_question: bool = False,
+) -> int:
+    """Return a simple 0-100 score estimating account security."""
+    score = 0
+    if len(password) >= 8:
+        score += 20
+    if len(password) >= 12:
+        score += 20
+    if any(ch.isdigit() for ch in password):
+        score += 20
+    if any(not ch.isalnum() for ch in password):
+        score += 20
+    if two_factor:
+        score += 10
+    if security_question:
+        score += 10
+    return min(score, 100)

--- a/backend/app/crud/users.py
+++ b/backend/app/crud/users.py
@@ -6,9 +6,30 @@ def get_user_by_username(db: Session, username: str) -> User | None:
     return db.query(User).filter(User.username == username).first()
 
 
-def create_user(db: Session, username: str, password_hash: str, role: str = "user") -> User:
-    user = User(username=username, password_hash=password_hash, role=role)
+def create_user(
+    db: Session,
+    *,
+    username: str,
+    password_hash: str,
+    role: str = "user",
+    security_score: int = 0,
+) -> User:
+    user = User(
+        username=username,
+        password_hash=password_hash,
+        role=role,
+        security_score=security_score,
+    )
     db.add(user)
     db.commit()
     db.refresh(user)
     return user
+
+
+def delete_user(db: Session, username: str) -> bool:
+    user = get_user_by_username(db, username)
+    if not user:
+        return False
+    db.delete(user)
+    db.commit()
+    return True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.api.user_stats import router as user_stats_router
 from app.api.events import router as events_router
 from app.api.last_logins import router as last_logins_router
 from app.api.access_logs import router as access_logs_router
+from app.api.admin import router as admin_router
 
 app = FastAPI(title="APIShield+")
 
@@ -57,6 +58,7 @@ app.include_router(user_stats_router)  # /api/user-calls
 app.include_router(events_router)   # /api/events
 app.include_router(last_logins_router)  # /api/last-logins
 app.include_router(access_logs_router)  # /api/access-logs
+app.include_router(admin_router)  # /admin endpoints
 
 
 @app.get("/ping")

--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -9,3 +9,4 @@ class User(Base):
     username = Column(String, unique=True, nullable=False, index=True)
     password_hash = Column(String, nullable=False)
     role = Column(String, nullable=False, default="user")
+    security_score = Column(Integer, nullable=False, default=0)

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -5,12 +5,15 @@ class UserCreate(BaseModel):
     username: str
     password: str
     role: str | None = None
+    two_factor: bool = False
+    security_question: bool = False
 
 
 class UserRead(BaseModel):
     id: int
     username: str
     role: str
+    security_score: int
 
     class Config:
         orm_mode = True

--- a/backend/tests/test_admin_users.py
+++ b/backend/tests/test_admin_users.py
@@ -1,0 +1,51 @@
+import os
+
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+os.environ['SECRET_KEY'] = 'test-secret'
+
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.security import get_password_hash  # noqa: E402
+from app.crud.users import create_user, get_user_by_username  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_function(_):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def teardown_function(_):
+    SessionLocal().close()
+
+
+def test_admin_can_create_and_delete_user():
+    db = SessionLocal()
+    create_user(db, username='admin', password_hash=get_password_hash('pw'), role='admin')
+    db.close()
+
+    resp = client.post('/login', json={'username': 'admin', 'password': 'pw'})
+    assert resp.status_code == 200
+    token = resp.json()['access_token']
+    headers = {'Authorization': f'Bearer {token}'}
+
+    payload = {
+        'username': 'bob',
+        'password': 'StrongPass!1',
+        'two_factor': True,
+        'security_question': True,
+    }
+    resp = client.post('/admin/users', json=payload, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['username'] == 'bob'
+    assert 0 < data['security_score'] <= 100
+
+    resp = client.delete('/admin/users/bob', headers=headers)
+    assert resp.status_code == 200
+
+    db = SessionLocal()
+    assert get_user_by_username(db, 'bob') is None
+    db.close()


### PR DESCRIPTION
## Summary
- allow admin to create and delete users
- track per-user security score based on optional features
- add tests for admin account management

## Testing
- `flake8 backend/app/api/admin.py backend/app/core/account_security.py backend/app/crud/users.py backend/app/models/users.py backend/app/schemas/users.py backend/app/api/auth.py backend/app/main.py backend/tests/test_admin_users.py`
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ed239602c832eb709b2a3100199d4