### PR TITLE
Add anomaly detection toggle to Pi menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,8 @@ python rpi/menu.py
 
 Select a feature to run it and press `Esc` to return to the menu.
 
+The menu now includes an **Edge Monitoring (Anomaly Detection)** option. Choosing it launches the edge service with ML-based request anomaly checks enabled, trading additional processing time for the ability to catch malicious traffic.
+
 
 ## License
 

--- a/rpi/menu.py
+++ b/rpi/menu.py
@@ -12,6 +12,10 @@ FEATURES = [
         [sys.executable, str(REPO_ROOT / "rpi" / "start_edge_service.py")],
     ),
     (
+        "Edge Monitoring (Anomaly Detection)",
+        [sys.executable, str(REPO_ROOT / "rpi" / "start_edge_service_anomaly.py")],
+    ),
+    (
         "Mininet Traffic",
         ["sudo", "python3", str(REPO_ROOT / "mininet" / "gen_traffic.py")],
     ),

--- a/rpi/start_edge_service_anomaly.py
+++ b/rpi/start_edge_service_anomaly.py
@@ -1,0 +1,6 @@
+import os
+from start_edge_service import main
+
+if __name__ == "__main__":
+    os.environ["ANOMALY_DETECTION"] = "true"
+    main()


### PR DESCRIPTION
## Summary
- add `Edge Monitoring (Anomaly Detection)` option in the Pi touchscreen menu
- create helper script to run edge service with `ANOMALY_DETECTION` enabled
- document the new menu entry in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ee23369c4832e93760502970578ef