### PR TITLE
feat: add authentication and legacy dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,21 +1,45 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { useState } from "react";
 import Sidebar from "./components/Sidebar";
 import Header from "./components/Header";
 import MainContent from "./components/MainContent";
+import LoginForm from "./LoginForm";
+import DashboardMain from "./DashboardMain";
 import { ThemeProvider } from "./theme/ThemeProvider";
 
 function App() {
+  const [token, setToken] = useState(localStorage.getItem("token"));
+
+  const handleLogin = (t) => {
+    localStorage.setItem("token", t);
+    setToken(t);
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    setToken(null);
+  };
+
+  if (!token) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <LoginForm onLogin={handleLogin} />
+      </div>
+    );
+  }
+
   return (
     <ThemeProvider>
       <Router>
         <div className="flex">
           <Sidebar />
           <div className="flex-1 flex flex-col min-h-screen bg-gray-50 dark:bg-[#1E1E2D]">
-            <Header />
+            <Header onLogout={handleLogout} />
             <main className="flex-1 overflow-y-auto p-4">
               <Routes>
-                <Route path="/" element={<MainContent />} />
-                <Route path="/metrics" element={<MainContent />} />
+                <Route path="/" element={<MainContent token={token} />} />
+                <Route path="/metrics" element={<MainContent token={token} />} />
+                <Route path="/legacy" element={<DashboardMain token={token} />} />
               </Routes>
             </main>
           </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,7 +1,7 @@
 import { Search, Bell, Sun, Moon } from "lucide-react";
 import { useTheme } from "../theme/ThemeProvider";
 
-const Header = () => {
+const Header = ({ onLogout }) => {
   const { theme, toggleTheme } = useTheme();
   return (
     <header className="flex items-center justify-between px-4 py-2 border-b bg-white dark:bg-[#27293D]">
@@ -24,6 +24,12 @@ const Header = () => {
           ) : (
             <Sun className="h-5 w-5" />
           )}
+        </button>
+        <button
+          onClick={onLogout}
+          className="text-sm px-2 py-1 rounded bg-gray-200 dark:bg-gray-700"
+        >
+          Logout
         </button>
         <img
           src="https://i.pravatar.cc/32"

--- a/frontend/src/components/MainContent.jsx
+++ b/frontend/src/components/MainContent.jsx
@@ -4,7 +4,7 @@ import LineChartCard from "./LineChartCard";
 import DonutChartCard from "./DonutChartCard";
 import { apiFetch } from "../api";
 
-const MainContent = () => {
+const MainContent = ({ token }) => {
   const [metrics, setMetrics] = useState({
     totalHacks: 0,
     blocked: 0,

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { NavLink } from "react-router-dom";
-import { Home, BarChart2, Menu } from "lucide-react";
+import { Home, BarChart2, Menu, List } from "lucide-react";
 
 const menuItems = [
   { label: "Dashboard", to: "/", icon: Home },
   { label: "Metrics", to: "/metrics", icon: BarChart2 },
+  { label: "Legacy", to: "/legacy", icon: List },
 ];
 
 const Sidebar = () => {


### PR DESCRIPTION
## Summary
- add login flow with token-based state
- include logout button and link to legacy dashboard features

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689051c8b620832eb533a671e9caca3a