### PR TITLE
Highlight user security and seed admin for demos

### DIFF
--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -27,7 +27,13 @@ export default function AttackSim({ user }) {
           await apiFetch("/register", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ username: name, password: info.password }),
+            body: JSON.stringify({
+              username: name,
+              password: info.password,
+              two_factor: info.twoFactor,
+              security_question: info.securityQuestion,
+              role: info.role,
+            }),
           });
           await fetch(`${SHOP_URL}/register`, {
             method: "POST",
@@ -37,6 +43,26 @@ export default function AttackSim({ user }) {
         } catch (err) {
           // ignore errors (likely already registered)
         }
+      }
+      try {
+        await apiFetch("/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            username: "admin",
+            password: "AdminPass!1",
+            role: "admin",
+            two_factor: true,
+            security_question: true,
+          }),
+        });
+        await fetch(`${SHOP_URL}/register`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username: "admin", password: "AdminPass!1" }),
+        });
+      } catch (err) {
+        // ignore admin registration errors
       }
     }
     ensureUsers();

--- a/frontend/src/UserAccounts.jsx
+++ b/frontend/src/UserAccounts.jsx
@@ -4,22 +4,28 @@ export const USER_DATA = {
   alice: {
     name: "Alice",
     password: "secret",
-
-    security: 30,
+    security: 0,
+    twoFactor: false,
+    securityQuestion: false,
+    role: "user",
     features: [
       "Weak password",
       "No MFA",
       "Token reuse allowed",
+      "No JWT protection",
     ],
   },
   ben: {
     name: "Ben",
     password: "ILikeN1G3R!A##?",
-
     security: 90,
+    twoFactor: true,
+    securityQuestion: false,
+    role: "user",
     features: [
       "Strong password requirements",
       "MFA enabled",
+      "JWT-protected endpoints",
       "Rotating chain token",
     ],
   },


### PR DESCRIPTION
## Summary
- track security features and score for Alice and Ben
- seed backend and demo shop with accounts using those features
- automatically create an admin account for further demos

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689054c66800832eb679e07a57e96545