### PR TITLE
feat: refresh metrics and add admin user creation

### DIFF
--- a/frontend/src/MetricsPage.jsx
+++ b/frontend/src/MetricsPage.jsx
@@ -24,10 +24,15 @@ export default function MetricsPage() {
   const [metrics, setMetrics] = useState(null);
 
   useEffect(() => {
-    fetch(`${API_BASE}/metrics`)
-      .then(res => res.text())
-      .then(text => setMetrics(parseMetrics(text)))
-      .catch(err => console.error("Metrics fetch error", err));
+    const load = () => {
+      fetch(`${API_BASE}/metrics`)
+        .then(res => res.text())
+        .then(text => setMetrics(parseMetrics(text)))
+        .catch(err => console.error("Metrics fetch error", err));
+    };
+    load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
   }, []);
 
   if (!metrics) {

--- a/frontend/src/components/AdminUserForm.jsx
+++ b/frontend/src/components/AdminUserForm.jsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { apiFetch } from "../api";
+
+function decode(token) {
+  try {
+    const [, payload] = token.split(".");
+    return JSON.parse(atob(payload));
+  } catch {
+    return null;
+  }
+}
+
+export default function AdminUserForm({ token }) {
+  const decoded = decode(token);
+  if (!decoded || decoded.role !== "admin") return null;
+
+  const [form, setForm] = useState({
+    username: "",
+    password: "",
+    role: "user",
+    two_factor: false,
+    security_question: false,
+  });
+  const [message, setMessage] = useState(null);
+
+  const handleChange = (e) => {
+    const { name, type, value, checked } = e.target;
+    setForm((f) => ({ ...f, [name]: type === "checkbox" ? checked : value }));
+  };
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setMessage(null);
+    try {
+      const resp = await apiFetch("/admin/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!resp.ok) throw new Error(await resp.text());
+      setMessage("User created successfully");
+      setForm({ username: "", password: "", role: "user", two_factor: false, security_question: false });
+    } catch (err) {
+      setMessage(`Error: ${err.message}`);
+    }
+  };
+
+  return (
+    <div className="mt-4 p-4 border rounded">
+      <h3 className="text-lg font-semibold mb-2">Create User</h3>
+      <form onSubmit={submit} className="space-y-2">
+        <input
+          className="block w-full p-1 border"
+          name="username"
+          value={form.username}
+          onChange={handleChange}
+          placeholder="Username"
+          required
+        />
+        <input
+          className="block w-full p-1 border"
+          type="password"
+          name="password"
+          value={form.password}
+          onChange={handleChange}
+          placeholder="Password"
+          required
+        />
+        <select
+          className="block w-full p-1 border"
+          name="role"
+          value={form.role}
+          onChange={handleChange}
+        >
+          <option value="user">User</option>
+          <option value="admin">Admin</option>
+        </select>
+        <label className="block">
+          <input
+            type="checkbox"
+            name="two_factor"
+            checked={form.two_factor}
+            onChange={handleChange}
+          />
+          <span className="ml-2">Two Factor</span>
+        </label>
+        <label className="block">
+          <input
+            type="checkbox"
+            name="security_question"
+            checked={form.security_question}
+            onChange={handleChange}
+          />
+          <span className="ml-2">Security Question</span>
+        </label>
+        <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded">
+          Create
+        </button>
+      </form>
+      {message && <p className="mt-2 text-sm">{message}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -5,7 +5,8 @@ const Header = ({ onLogout }) => {
   const { theme, toggleTheme } = useTheme();
   return (
     <header className="flex items-center justify-between px-4 py-2 border-b bg-white dark:bg-[#27293D]">
-      <div className="flex items-center">
+      <div className="flex items-center space-x-4">
+        <h1 className="text-2xl font-bold">APIShield+</h1>
         <Search className="h-5 w-5 text-gray-500" />
         <input
           type="text"
@@ -31,11 +32,6 @@ const Header = ({ onLogout }) => {
         >
           Logout
         </button>
-        <img
-          src="https://i.pravatar.cc/32"
-          alt="avatar"
-          className="rounded-full h-8 w-8"
-        />
       </div>
     </header>
   );

--- a/frontend/src/components/MainContent.jsx
+++ b/frontend/src/components/MainContent.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import MetricCard from "./MetricCard";
 import LineChartCard from "./LineChartCard";
 import DonutChartCard from "./DonutChartCard";
+import AdminUserForm from "./AdminUserForm";
 import { apiFetch } from "../api";
 
 const MainContent = ({ token }) => {
@@ -36,6 +37,8 @@ const MainContent = ({ token }) => {
       }
     }
     load();
+    const id = setInterval(load, 5000);
+    return () => clearInterval(id);
   }, []);
 
   const donutData = [
@@ -71,6 +74,7 @@ const MainContent = ({ token }) => {
       </div>
       <LineChartCard data={lineData} />
       <DonutChartCard data={donutData} />
+      <AdminUserForm token={token} />
     </div>
   );
 };

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -17,7 +17,7 @@ const Sidebar = () => {
       }`}
     >
       <div className="flex items-center justify-between p-4">
-        {!collapsed && <span className="font-bold">Arion</span>}
+        {!collapsed && <span className="font-bold">APIShield+</span>}
         <button
           onClick={() => setCollapsed(!collapsed)}
           className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700"


### PR DESCRIPTION
## Summary
- remove dynamic profile avatar and rebrand dashboard to **APIShield+**
- refresh dashboard metrics in real time
- allow admins to create new users from the UI

## Testing
- `pytest`
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6890585e0bdc832eaa765e26d53cab65