### PR TITLE
Add security score column and enhance login page

### DIFF
--- a/backend/alembic/versions/fffff_add_security_score_to_users_table.py
+++ b/backend/alembic/versions/fffff_add_security_score_to_users_table.py
@@ -1,0 +1,25 @@
+"""add security_score column to users table
+
+Revision ID: fffff
+Revises: eeeee
+Create Date: 2025-07-06 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'fffff'
+down_revision: Union[str, None] = 'eeeee'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'users',
+        sa.Column('security_score', sa.Integer(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'security_score')

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -26,28 +26,43 @@ export default function LoginForm({ onLogin }) {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <label>
-        Username:
-        <input value={username} onChange={e => setUsername(e.target.value)} />
-      </label>
-      <label>
-        Password:
-        <input
-          type={showPassword ? "text" : "password"}
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-        />
+    <div className="w-full max-w-sm p-6 bg-white rounded shadow">
+      <h1 className="text-2xl font-bold mb-4 text-center">API Shield +</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">Username</label>
+          <input
+            className="w-full px-3 py-2 border rounded"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Password</label>
+          <div className="flex">
+            <input
+              className="w-full px-3 py-2 border rounded"
+              type={showPassword ? "text" : "password"}
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(sp => !sp)}
+              className="ml-2 px-2 py-1 border rounded"
+            >
+              {showPassword ? "Hide" : "Show"}
+            </button>
+          </div>
+        </div>
         <button
-          type="button"
-          onClick={() => setShowPassword(sp => !sp)}
-          style={{ marginLeft: "0.5rem" }}
+          type="submit"
+          className="w-full py-2 bg-blue-500 text-white rounded"
         >
-          {showPassword ? "Hide" : "Show"}
+          Login
         </button>
-      </label>
-      <button type="submit">Login</button>
-      {error && <p style={{ color: "red" }}>{error}</p>}
-    </form>
+        {error && <p className="text-red-500">{error}</p>}
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Alembic migration to introduce `security_score` on users
- restyle login form with API Shield+ branding

## Testing
- `pytest`
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68905dec5644832ea5c58d92d865f02e