### PR TITLE
Improve legacy dashboard styling and link attack stats

### DIFF
--- a/frontend/src/AlertsChart.jsx
+++ b/frontend/src/AlertsChart.jsx
@@ -22,7 +22,7 @@ ChartJS.register(
   Legend
 );
 
-export default function AlertsChart({ token }) {
+export default function AlertsChart({ token, refresh }) {
   const [stats, setStats] = useState([]);
   const [error, setError] = useState(null);
 
@@ -41,7 +41,7 @@ export default function AlertsChart({ token }) {
   useEffect(() => {
     loadStats();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [refresh]);
 
   if (error) return <p className="error-text">{error}</p>;
   if (stats.length === 0) return <p>No data yet.</p>;

--- a/frontend/src/AlertsSummary.jsx
+++ b/frontend/src/AlertsSummary.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function AlertsSummary({ token }) {
+export default function AlertsSummary({ token, refresh }) {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
 
@@ -20,7 +20,7 @@ export default function AlertsSummary({ token }) {
   useEffect(() => {
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [refresh]);
 
   if (error) return <p className="error-text">{error}</p>;
   if (!data) return <p>Loading...</p>;

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -9,9 +9,10 @@ const DUMMY_PASSWORDS = [
   "password1",
   "secret",
   "letmein",
+  "password123",
 ];
 
-export default function AttackSim({ user }) {
+export default function AttackSim({ user, onComplete }) {
   const [targetUser, setTargetUser] = useState(user || "alice");
 
   useEffect(() => {
@@ -207,6 +208,9 @@ export default function AttackSim({ user }) {
     const totalTime = (performance.now() - start) / 1000;
     setResults((r) => ({ ...r, total_time: totalTime }));
     setRunning(false);
+    if (onComplete) {
+      onComplete();
+    }
   };
 
   return (

--- a/frontend/src/DashboardMain.jsx
+++ b/frontend/src/DashboardMain.jsx
@@ -12,6 +12,7 @@ import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
 import JwtViewer from "./JwtViewer";
 import EndpointDemo from "./EndpointDemo";
+import "./legacy.css";
 
 export default function DashboardMain({ token }) {
   const [refreshKey, setRefreshKey] = useState(0);
@@ -24,14 +25,17 @@ export default function DashboardMain({ token }) {
       <LoginStatus token={token} />
       <JwtViewer token={token} />
       <EndpointDemo token={token} />
-      <ScoreForm onNewAlert={() => setRefreshKey(k => k + 1)} />
-      <AlertsSummary token={token} />
-      <AlertsChart token={token} />
+      <ScoreForm onNewAlert={() => setRefreshKey((k) => k + 1)} />
+      <AlertsSummary token={token} refresh={refreshKey} />
+      <AlertsChart token={token} refresh={refreshKey} />
       <AlertsTable refresh={refreshKey} token={token} />
       <EventsTable token={token} />
       <ShopIframe />
       <div className="attack-section">
-        <AttackSim user={selectedUser} />
+        <AttackSim
+          user={selectedUser}
+          onComplete={() => setRefreshKey((k) => k + 1)}
+        />
         <div className="security-box">
           <SecurityToggle />
           <AutoLogoutToggle />

--- a/frontend/src/legacy.css
+++ b/frontend/src/legacy.css
@@ -1,0 +1,73 @@
+.app-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+  font-family: Arial, sans-serif;
+  color: #1f2937;
+}
+
+.dashboard-header {
+  font-size: 2rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.attack-section {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.attack-sim h2 {
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.attack-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.attack-controls label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+}
+
+.attack-controls select,
+.attack-controls input {
+  margin-top: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.25rem;
+}
+
+.attack-controls button {
+  padding: 0.5rem 1rem;
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.attack-controls button:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.attack-results {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.error-text {
+  color: #dc2626;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
## Summary
- Style legacy dashboard with clearer layout and buttons
- Refresh alert metrics and charts after simulations
- Ensure credential stuffing simulator captures Alice's data

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689063b7e848832e96835c6b2e9ba9b0