### PR TITLE
Fix credential stuffing simulation missing user info

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -102,8 +102,23 @@ async def login_for_access_token(
 
 
 @router.get("/api/me")
-async def read_me(current_user: dict = Depends(get_current_user)):
-    return current_user
+async def read_me(current_user=Depends(get_current_user)):
+    """Return basic information about the authenticated user.
+
+    The credential stuffing simulator expects to see both the username and
+    the password hash of the compromised account.  Returning the SQLAlchemy
+    model directly can result in the password hash being omitted or the
+    object not being JSON serialisable in some environments.  Explicitly
+    constructing the response dictionary ensures these fields are always
+    present.
+    """
+
+    return {
+        "id": current_user.id,
+        "username": current_user.username,
+        "password_hash": current_user.password_hash,
+        "role": current_user.role,
+    }
 
 
 @router.post("/logout")

--- a/backend/tests/test_me_endpoint.py
+++ b/backend/tests/test_me_endpoint.py
@@ -1,0 +1,37 @@
+import os
+
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+os.environ['SECRET_KEY'] = 'test-secret'
+
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.security import get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_function(_):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    with SessionLocal() as db:
+        create_user(db, username='alice', password_hash=get_password_hash('pw'))
+
+
+def teardown_function(_):
+    SessionLocal().close()
+
+
+def _auth_headers():
+    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+    token = resp.json()['access_token']
+    return {'Authorization': f'Bearer {token}'}
+
+
+def test_me_returns_password_hash_and_username():
+    resp = client.get('/api/me', headers=_auth_headers())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['username'] == 'alice'
+    assert 'password_hash' in data and data['password_hash']


### PR DESCRIPTION
## Summary
- ensure `/api/me` returns explicit user details including password hashes
- add regression test verifying password hash and username are exposed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689077c7e458832e93bbe81fc93b1c5d