### PR TITLE
feat(frontend): expose configurable API and shop URLs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "cross-env REACT_APP_API_BASE=http://localhost:8001 REACT_APP_SHOP_URL=http://localhost:3005 react-scripts start",
-    "build": "cross-env REACT_APP_API_BASE=http://localhost:8001 REACT_APP_SHOP_URL=http://localhost:3005 react-scripts build",
-    "test": "cross-env REACT_APP_API_BASE=http://localhost:8001 REACT_APP_SHOP_URL=http://localhost:3005 react-scripts test",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,5 @@
-export const API_BASE = process.env.REACT_APP_API_BASE || "";
+export const API_BASE =
+  process.env.REACT_APP_API_BASE || window.location.origin;
 export const API_KEY = process.env.REACT_APP_API_KEY || "";
 
 export function logout() {


### PR DESCRIPTION
## Summary
- default API base to `window.location.origin` when `REACT_APP_API_BASE` is unset
- remove hard-coded localhost URLs from npm scripts so Helm charts can supply `REACT_APP_API_BASE` and `REACT_APP_SHOP_URL`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68909048f79c832e9c0141f7749fc930