### PR TITLE
Pass auth token from Dashboard to ScoreForm and AlertsTable

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -6,6 +6,8 @@ import { apiFetch } from "../api";
 
 function Dashboard() {
   const [ping, setPing] = useState(null);
+  const [refresh, setRefresh] = useState(0);
+  const token = localStorage.getItem("token");
 
   useEffect(() => {
     apiFetch("/ping")
@@ -14,16 +16,18 @@ function Dashboard() {
       .catch((err) => console.error("Ping failed:", err));
   }, []);
 
+  const handleNewAlert = () => setRefresh((r) => r + 1);
+
   return (
     <div style={{ padding: "1rem" }}>
       <h1>APIShield+ Dashboard</h1>
       <p>Backend ping says: {ping ?? "Loading…"} </p>
 
-      <ScoreForm />
+      <ScoreForm token={token} onNewAlert={handleNewAlert} />
 
       <hr style={{ margin: "2rem 0" }} />
 
-      <AlertsTable />
+      <AlertsTable token={token} refresh={refresh} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Read auth token from local storage in Dashboard and maintain refresh counter.
- Pass token to ScoreForm and AlertsTable and refresh alerts when ScoreForm reports a new alert.

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689093875398832eb50b2dadcd13c20f