### PR TITLE
Gate config and chain endpoints behind admin check

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,7 +30,7 @@ function App() {
       <h1 className="dashboard-header">APIShield+ Dashboard</h1>
       <UserAccounts onSelect={setSelectedUser} />
       <LoginStatus token={token} />
-      <ScoreForm onNewAlert={() => setRefreshKey(k => k + 1)} />
+      <ScoreForm token={token} onNewAlert={() => setRefreshKey(k => k + 1)} />
       <AlertsChart token={token} />
       <AlertsTable refresh={refreshKey} token={token} />
       <EventsTable token={token} />


### PR DESCRIPTION
## Summary
- Verify admin role before fetching `/config` and `/api/security/chain`
- Display a warning instead of logging when security endpoints return 401/403
- Pass auth token to `ScoreForm` component

## Testing
- `npm test --silent -- --watchAll=false`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689094ee7300832ea55394b4bbd308c7