### PR TITLE
Add logout functionality to dashboard

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -150,6 +150,16 @@ body {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
 }
 
+.logout-button {
+  padding: 0.5rem 1rem;
+  background-color: #e53935;
+  border: none;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
 .progress {
   width: 100%;
   background: #eee;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,11 @@ function App() {
   const [token, setToken] = useState(localStorage.getItem("token"));
   const [selectedUser, setSelectedUser] = useState("alice");
 
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    setToken(null);
+  };
+
   if (!token) {
     return (
       <div className="app-container">
@@ -30,6 +35,7 @@ function App() {
       <h1 className="dashboard-header">APIShield+ Dashboard</h1>
       <UserAccounts onSelect={setSelectedUser} />
       <LoginStatus token={token} />
+      <button className="logout-button" onClick={handleLogout}>Logout</button>
       <ScoreForm token={token} onNewAlert={() => setRefreshKey(k => k + 1)} />
       <AlertsChart token={token} />
       <AlertsTable refresh={refreshKey} token={token} />


### PR DESCRIPTION
## Summary
- add a logout handler that clears stored JWT and resets auth state
- expose a Logout button on the dashboard and style it to match the UI

## Testing
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689097e9f878832ea9af9ac466866a13