### PR TITLE
Use .env to configure demo shop API

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://localhost:8001

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,6 +4,12 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 The demo shop backend used by the dashboard is located in `../demo-shop`.
 Refer to the root README for instructions on starting the shop.
 
+## Environment Variables
+
+The frontend is preconfigured to talk to the demo shop backend running on
+`http://localhost:8001`. This base URL is provided via the
+`REACT_APP_API_BASE` variable in the `.env` file.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,5 @@
       "last 1 safari version"
     ]
   },
-  "devDependencies": {
-    "cross-env": "^7.0.3"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
## Summary
- use `.env` to set `REACT_APP_API_BASE` for the frontend
- drop cross-env dependency so scripts call `react-scripts` directly
- document the API base variable in the frontend README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68909e096c64832eb96b57198a34d46d