### PR TITLE
Log logout events

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -120,8 +120,12 @@ async def read_me(current_user=Depends(get_current_user)):
         "role": current_user.role,
     }
 
-
 @router.post("/logout")
-async def logout(token: str = Depends(oauth2_scheme)):
+async def logout(
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db),
+):
+    user = await get_current_user(token=token, db=db)
+    log_event(db, user.username, "logout", True)
     revoke_token(token)
     return {"detail": "Logged out"}

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -31,3 +31,21 @@ def test_login_event_logged():
     assert resp.status_code == 200
     events = resp.json()
     assert any(e['action'] == 'login' and e['success'] for e in events)
+
+
+def test_logout_event_logged():
+    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+    assert resp.status_code == 200
+    token = resp.json()['access_token']
+    headers = {'Authorization': f'Bearer {token}'}
+
+    resp = client.post('/logout', headers=headers)
+    assert resp.status_code == 200
+
+    # Obtain a new token to access the events endpoint
+    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+    token = resp.json()['access_token']
+    resp = client.get('/api/events', headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 200
+    events = resp.json()
+    assert any(e['action'] == 'logout' and e['success'] for e in events)


### PR DESCRIPTION
## Summary
- log logout events before token revocation
- add regression test ensuring logout events are recorded

## Testing
- `pytest -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68909e695708832ea505c22da864575e