### PR TITLE
Log logout events

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -125,6 +125,11 @@ async def read_me(current_user=Depends(get_current_user)):
 
 
 @router.post("/logout")
-async def logout(token: str = Depends(oauth2_scheme)):
+async def logout(
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db),
+):
+    user = await get_current_user(token=token, db=db)
+    log_event(db, user.username, "logout", True)
     revoke_token(token)
     return {"detail": "Logged out"}

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
@@ -31,3 +32,22 @@ def test_login_event_logged():
     assert resp.status_code == 200
     events = resp.json()
     assert any(e['action'] == 'login' and e['success'] for e in events)
+
+
+def test_logout_event_logged():
+    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+    assert resp.status_code == 200
+    token = resp.json()['access_token']
+
+    resp = client.post('/logout', headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 200
+
+    time.sleep(1)
+    resp = client.post('/login', json={'username': 'alice', 'password': 'pw'})
+    assert resp.status_code == 200
+    new_token = resp.json()['access_token']
+
+    resp = client.get('/api/events', headers={'Authorization': f'Bearer {new_token}'})
+    assert resp.status_code == 200
+    events = resp.json()
+    assert any(e['action'] == 'logout' and e['success'] for e in events)


### PR DESCRIPTION
## Summary
- log logout events before token revocation
- cover logout events with tests

## Testing
- `flake8 app/api/auth.py tests/test_events.py`
- `pytest tests/test_events.py::test_logout_event_logged -q`


------
https://chatgpt.com/codex/tasks/task_e_68909f80a190832ebf7d5f229f1f5813