### PR TITLE
Group dashboard sections for consistent styling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -18,6 +18,14 @@ body {
   margin-bottom: 2rem;
 }
 
+.dashboard-section {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
+}
+
 .score-form {
   display: flex;
   gap: 1rem;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -32,17 +32,31 @@ function App() {
   return (
     <div className="app-container">
       <h1 className="dashboard-header">APIShield+ Dashboard</h1>
-      <UserAccounts onSelect={setSelectedUser} />
-      <LoginStatus token={token} />
-      <button className="logout-button" onClick={handleLogout}>Logout</button>
-      <ScoreForm token={token} onNewAlert={() => setRefreshKey(k => k + 1)} />
-      <AlertsChart token={token} />
-      <AlertsTable refresh={refreshKey} token={token} />
-      <EventsTable token={token} />
-      <div className="attack-section">
-        <AttackSim user={selectedUser} />
-        <div className="security-box">
-          <SecurityToggle />
+      <div className="dashboard-section">
+        <UserAccounts onSelect={setSelectedUser} />
+      </div>
+      <div className="dashboard-section">
+        <LoginStatus token={token} />
+        <button className="logout-button" onClick={handleLogout}>Logout</button>
+      </div>
+      <div className="dashboard-section">
+        <ScoreForm token={token} onNewAlert={() => setRefreshKey(k => k + 1)} />
+      </div>
+      <div className="dashboard-section">
+        <AlertsChart token={token} />
+      </div>
+      <div className="dashboard-section">
+        <AlertsTable refresh={refreshKey} token={token} />
+      </div>
+      <div className="dashboard-section">
+        <EventsTable token={token} />
+      </div>
+      <div className="dashboard-section">
+        <div className="attack-section">
+          <AttackSim user={selectedUser} />
+          <div className="security-box">
+            <SecurityToggle />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Wrap major dashboard components in a `.dashboard-section` container for unified layout
- Introduce `.dashboard-section` style for spacing, background, and shadows

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6890a31b2180832e8d0b02ebb922b414