### PR TITLE
Use pathlib for credential file path in stuffing script

### DIFF
--- a/scripts/stuffing.py
+++ b/scripts/stuffing.py
@@ -2,6 +2,7 @@ import requests
 import itertools
 import time
 import argparse
+from pathlib import Path
 
 
 def load_creds(path, limit=None):
@@ -15,7 +16,9 @@ def load_creds(path, limit=None):
     return passwords
 
 
-passwords = load_creds("scripts/data/rockyou.txt", limit=5000)
+passwords = load_creds(
+    Path(__file__).with_name("data").joinpath("rockyou.txt"), limit=5000
+)
 pool = itertools.cycle(passwords)
 
 


### PR DESCRIPTION
## Summary
- load passwords from a path derived from the script location instead of a hard-coded string
- import `pathlib.Path` for location-independent credential loading

## Testing
- `python -m py_compile scripts/stuffing.py`
- `pytest` *(fails: 1 failed, 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6890a7cdc6ec832e894e23362a2e0334