### PR TITLE
Forward invalid login attempts to backend

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -86,6 +86,15 @@ app.post('/login', async (req, res) => {
     if (FORWARD_API) {
       try {
         await axios.post(
+          `${API_BASE}/login`,
+          { username, password },
+          { timeout: API_TIMEOUT }
+        );
+      } catch (e) {
+        // Ignore expected 401 from invalid credentials
+      }
+      try {
+        await axios.post(
           `${API_BASE}/score`,
           {
             client_ip: req.ip,


### PR DESCRIPTION
## Summary
- forward invalid login attempts to backend /login endpoint when API forwarding is enabled
- ignore expected 401 response and continue scoring failed auth attempts

## Testing
- `node --check demo-shop/server.js`


------
https://chatgpt.com/codex/tasks/task_e_6890a7523ae0832e8ecb87d587497d08