### PR TITLE
Handle score request errors

### DIFF
--- a/scripts/stuffing.py
+++ b/scripts/stuffing.py
@@ -88,7 +88,7 @@ def attack(
             )
             if score_resp.json().get("status") == "blocked":
                 blocked += 1
-        except Exception as exc:
+        except requests.exceptions.RequestException as exc:
             print("SCORE ERROR:", exc)
 
         if login_ok:


### PR DESCRIPTION
## Summary
- guard score post in stuffing script against request failures

## Testing
- `python -m py_compile scripts/stuffing.py`
- `pytest` *(fails: backend/tests/test_events.py::test_logout_event_logged)*

------
https://chatgpt.com/codex/tasks/task_e_6890abd6d7c0832eb68013bebb254d8a