### PR TITLE
Call backend logout when session ends

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -137,7 +137,21 @@ const apiResp = await axios.post(
   res.json({ status: 'ok' });
 });
 
-app.post('/logout', (req, res) => {
+app.post('/logout', async (req, res) => {
+  if (FORWARD_API && req.session.apiToken) {
+    try {
+      await axios.post(
+        `${API_BASE}/logout`,
+        null,
+        {
+          headers: { Authorization: `Bearer ${req.session.apiToken}` },
+          timeout: API_TIMEOUT,
+        }
+      );
+    } catch (e) {
+      console.error('Backend logout failed');
+    }
+  }
   req.session.apiToken = null;
   req.session.destroy(() => res.json({ status: 'ok' }));
 });


### PR DESCRIPTION
## Summary
- call backend /logout before destroying session when API forwarding is enabled

## Testing
- `node --check server.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890abcc6540832eb9c2cd874cffde7a