### PR TITLE
Add API key and chain support to attack script

### DIFF
--- a/scripts/stuffing.py
+++ b/scripts/stuffing.py
@@ -28,6 +28,8 @@ def attack(
     use_jwt=False,
     score_base="http://localhost:8001",
     shop_url="http://localhost:3005",
+    api_key=None,
+    chain_url="/api/security/chain",
 ):
     """Send repeated login attempts and report detection results.
 
@@ -45,6 +47,19 @@ def attack(
     start = time.time()
 
     session = requests.Session()
+    base_headers = {}
+    chain = None
+    chain_endpoint = None
+    if api_key:
+        base_headers["X-API-Key"] = api_key
+        if chain_url:
+            chain_endpoint = chain_url if chain_url.startswith("http") else f"{score_base}{chain_url}"
+            try:
+                resp = session.get(chain_endpoint, headers=base_headers, timeout=3)
+                if resp.ok:
+                    chain = resp.json().get("chain")
+            except Exception as exc:
+                print("CHAIN ERROR:", exc)
     for i in range(1, attempts + 1):
         pwd = next(pool)
         ip = "10.0.0.1"
@@ -81,13 +96,24 @@ def attack(
         }
 
         try:
-            score_resp = requests.post(
+            headers = dict(base_headers)
+            if chain:
+                headers["X-Chain-Password"] = chain
+            score_resp = session.post(
                 f"{score_base}/score",
                 json=score_payload,
+                headers=headers,
                 timeout=3,
             )
             if score_resp.json().get("status") == "blocked":
                 blocked += 1
+            if chain_endpoint:
+                try:
+                    resp = session.get(chain_endpoint, headers=base_headers, timeout=3)
+                    if resp.ok:
+                        chain = resp.json().get("chain")
+                except Exception as exc:
+                    print("CHAIN ERROR:", exc)
         except Exception as exc:
             print("SCORE ERROR:", exc)
 
@@ -149,6 +175,12 @@ if __name__ == "__main__":
         help="Detector API base URL",
     )
     parser.add_argument("--shop-url", default="http://localhost:3005", help="Demo shop base URL")
+    parser.add_argument("--api-key", help="API key for protected endpoints")
+    parser.add_argument(
+        "--chain-url",
+        default="/api/security/chain",
+        help="Endpoint to fetch rotating chain value",
+    )
     args = parser.parse_args()
     attack(
         rate_per_sec=args.rate,
@@ -156,4 +188,6 @@ if __name__ == "__main__":
         use_jwt=args.jwt,
         score_base=args.score_base,
         shop_url=args.shop_url,
+        api_key=args.api_key,
+        chain_url=args.chain_url,
     )


### PR DESCRIPTION
## Summary
- add `--api-key` and `--chain-url` CLI options to stuffing attack script
- include API key and chain headers when hitting `/score`, refreshing the chain each time

## Testing
- `pytest` *(fails: backend/tests/test_events.py::test_logout_event_logged)*

------
https://chatgpt.com/codex/tasks/task_e_6890ac621c40832e8a0a928ef50ed22f