### PR TITLE
Restrict CORS to localhost frontend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,13 +24,7 @@ from app.api.access_logs import router as access_logs_router
 
 app = FastAPI(title="APIShield+")
 
-# Allow origins can be configured via environment variable
-allow_origins = [
-    origin.strip()
-    for origin in os.getenv("ALLOW_ORIGINS", "*").split(",")
-    if origin.strip()
-]
-
+allow_origins = ["http://localhost:3000"]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allow_origins,


### PR DESCRIPTION
## Summary
- restrict CORS policy to only allow http://localhost:3000

## Testing
- `pytest backend/tests`
- `flake8 backend` *(fails: E402 module level import not at top of file, F401 'Alert' imported but unused, F401 'User' imported but unused, W291 trailing whitespace, E128 continuation line under-indented for visual indent, E122 continuation line missing indentation or outdented, E302 expected 2 blank lines, found 1)*
- `curl -H "Origin: http://localhost:3000" -i http://localhost:8001/ping`


------
https://chatgpt.com/codex/tasks/task_e_6890b60c1edc832e933f2249809ee5ac