### PR TITLE
Forward invalid logins to backend

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -91,7 +91,10 @@ app.post('/login', async (req, res) => {
           { timeout: API_TIMEOUT }
         );
       } catch (e) {
-        // Ignore expected 401 from invalid credentials
+        // Ignore expected 401 but surface other errors
+        if (e.response?.status !== 401) {
+          console.error('Login API call failed');
+        }
       }
       try {
         await axios.post(


### PR DESCRIPTION
## Summary
- Forward invalid login attempts to backend /login
- Surface non-401 errors while ignoring expected 401 responses

## Testing
- `cd demo-shop && npm test >/tmp/test.log && cat /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_6890b807ef54832ea98538a60c6dd30d