### PR TITLE
feat: share auth token across apps

### DIFF
--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.db import get_db
+from app.core.events import log_event
+
+router = APIRouter(prefix="/api/audit", tags=["audit"])
+
+
+class AuditLog(BaseModel):
+    event: str
+    username: str | None = None
+    success: bool = True
+
+
+@router.post("/log")
+def audit_log(log: AuditLog, db: Session = Depends(get_db)):
+    """Record an audit event from a frontend."""
+    log_event(db, log.username, log.event, log.success)
+    return {"status": "logged"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.api.user_stats import router as user_stats_router
 from app.api.events import router as events_router
 from app.api.last_logins import router as last_logins_router
 from app.api.access_logs import router as access_logs_router
+from app.api.audit import router as audit_router
 
 app = FastAPI(title="APIShield+")
 
@@ -57,6 +58,7 @@ app.include_router(user_stats_router)  # /api/user-calls
 app.include_router(events_router)   # /api/events
 app.include_router(last_logins_router)  # /api/last-logins
 app.include_router(access_logs_router)  # /api/access-logs
+app.include_router(audit_router)  # /api/audit/log
 
 
 @app.get("/ping")

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import ScoreForm from "./ScoreForm";
 import AlertsTable from "./AlertsTable";
 import EventsTable from "./EventsTable";
@@ -9,16 +9,26 @@ import AttackSim from "./AttackSim";
 import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
 import "./App.css";
+import { TOKEN_KEY, logAuditEvent } from "./api";
 
 function App() {
   const [refreshKey, setRefreshKey] = useState(0);
-  const [token, setToken] = useState(localStorage.getItem("token"));
+  const [token, setToken] = useState(localStorage.getItem(TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
 
-  const handleLogout = () => {
-    localStorage.removeItem("token");
+  const handleLogout = async () => {
+    await logAuditEvent("user_logout");
+    localStorage.removeItem(TOKEN_KEY);
     setToken(null);
   };
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const current = localStorage.getItem(TOKEN_KEY);
+      setToken(prev => (prev === current ? prev : current));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
 
   if (!token) {
     return (

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { apiFetch } from "./api";
+import { apiFetch, TOKEN_KEY, logAuditEvent } from "./api";
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
@@ -17,7 +17,8 @@ export default function LoginForm({ onLogin }) {
       });
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
-      localStorage.setItem("token", data.access_token);
+      localStorage.setItem(TOKEN_KEY, data.access_token);
+      await logAuditEvent("user_login_success");
       onLogin(data.access_token);
     } catch (err) {
       setError(err.message);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,12 +2,12 @@
 import React, { useEffect, useState } from "react";
 import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
-import { apiFetch } from "../api";
+import { apiFetch, TOKEN_KEY } from "../api";
 
 function Dashboard() {
   const [ping, setPing] = useState(null);
   const [refresh, setRefresh] = useState(0);
-  const token = localStorage.getItem("token");
+  const token = localStorage.getItem(TOKEN_KEY);
 
   useEffect(() => {
     apiFetch("/ping")


### PR DESCRIPTION
## Summary
- use shared `apiShieldAuthToken` between dashboard and demo shop
- send login/logout audit events to new backend endpoint
- sync auth state between apps via token polling

## Testing
- `pytest`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6890ba8ef09c832e94dbe3e2fc77f2b2