### PR TITLE
Standardize auth token key across frontends

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { AUTH_TOKEN_KEY } from "./api";
 import ScoreForm from "./ScoreForm";
 import AlertsTable from "./AlertsTable";
 import EventsTable from "./EventsTable";
@@ -12,11 +13,11 @@ import "./App.css";
 
 function App() {
   const [refreshKey, setRefreshKey] = useState(0);
-  const [token, setToken] = useState(localStorage.getItem("token"));
+  const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
 
   const handleLogout = () => {
-    localStorage.removeItem("token");
+    localStorage.removeItem(AUTH_TOKEN_KEY);
     setToken(null);
   };
 

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { apiFetch } from "./api";
+import { apiFetch, AUTH_TOKEN_KEY } from "./api";
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
@@ -17,7 +17,7 @@ export default function LoginForm({ onLogin }) {
       });
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
-      localStorage.setItem("token", data.access_token);
+      localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
       onLogin(data.access_token);
     } catch (err) {
       setError(err.message);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,16 +1,17 @@
 export const API_BASE =
   process.env.REACT_APP_API_BASE || window.location.origin;
 export const API_KEY = process.env.REACT_APP_API_KEY || "";
+export const AUTH_TOKEN_KEY = "apiShieldAuthToken";
 
 export function logout() {
-  localStorage.removeItem("token");
+  localStorage.removeItem(AUTH_TOKEN_KEY);
   window.location.reload();
 }
 
 export async function apiFetch(path, options = {}) {
   const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
   const headers = { ...(options.headers || {}) };
-  const token = localStorage.getItem("token");
+  const token = localStorage.getItem(AUTH_TOKEN_KEY);
   const skipAuth =
     url.endsWith("/login") || url.endsWith("/register") || url.endsWith("/api/token");
   if (token && !skipAuth && !headers["Authorization"]) {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,12 +2,12 @@
 import React, { useEffect, useState } from "react";
 import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
-import { apiFetch } from "../api";
+import { apiFetch, AUTH_TOKEN_KEY } from "../api";
 
 function Dashboard() {
   const [ping, setPing] = useState(null);
   const [refresh, setRefresh] = useState(0);
-  const token = localStorage.getItem("token");
+  const token = localStorage.getItem(AUTH_TOKEN_KEY);
 
   useEffect(() => {
     apiFetch("/ping")

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -1,4 +1,5 @@
 const API_BASE = 'http://localhost:3005';
+const AUTH_TOKEN_KEY = 'apiShieldAuthToken';
 let username = null;
 
 function setContent(html) {
@@ -136,6 +137,7 @@ function showLogin() {
         body: JSON.stringify({ username, password: pw }),
         noAuth: true
       });
+      localStorage.setItem(AUTH_TOKEN_KEY, 'true');
       document.getElementById('loginBtn').style.display = 'none';
       document.getElementById('logoutBtn').style.display = 'inline-block';
       updateCartCount();
@@ -143,6 +145,7 @@ function showLogin() {
     } catch (e) {
       showMessage('Login failed', true);
       username = null;
+      localStorage.removeItem(AUTH_TOKEN_KEY);
     }
   });
   document.getElementById('registerLink').addEventListener('click', showRegister);
@@ -177,6 +180,13 @@ function showRegister() {
 
 // Determine whether the user already has an active session
 async function checkSession() {
+  if (!localStorage.getItem(AUTH_TOKEN_KEY)) {
+    username = null;
+    document.getElementById('loginBtn').style.display = 'inline-block';
+    document.getElementById('logoutBtn').style.display = 'none';
+    updateCartCount();
+    return;
+  }
   try {
     const data = await fetchJSON(`${API_BASE}/session`, { noAuth: true });
     if (data.loggedIn) {
@@ -184,14 +194,18 @@ async function checkSession() {
       document.getElementById('loginBtn').style.display = 'none';
       document.getElementById('logoutBtn').style.display = 'inline-block';
     } else {
+      localStorage.removeItem(AUTH_TOKEN_KEY);
       username = null;
       document.getElementById('loginBtn').style.display = 'inline-block';
       document.getElementById('logoutBtn').style.display = 'none';
     }
-    updateCartCount();
   } catch {
-    // Ignore errors – treat as not logged in
+    localStorage.removeItem(AUTH_TOKEN_KEY);
+    username = null;
+    document.getElementById('loginBtn').style.display = 'inline-block';
+    document.getElementById('logoutBtn').style.display = 'none';
   }
+  updateCartCount();
 }
 
 async function logout() {
@@ -201,6 +215,7 @@ async function logout() {
     showMessage('Logout failed', true);
     return;
   }
+  localStorage.removeItem(AUTH_TOKEN_KEY);
   username = null;
   document.getElementById('loginBtn').style.display = 'inline-block';
   document.getElementById('logoutBtn').style.display = 'none';


### PR DESCRIPTION
## Summary
- Use shared `apiShieldAuthToken` key for authentication in dashboard frontend
- Manage the same key in shop UI's login, logout, and session checks

## Testing
- `cd frontend && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890baa51538832e810886674577d076