### PR TITLE
Enable batch migrations for SQLite

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -43,6 +43,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        render_as_batch=True,
     )
 
     with context.begin_transaction():
@@ -64,7 +65,9 @@ def run_migrations_online() -> None:
 
     with connectable.connect() as connection:
         context.configure(
-            connection=connection, target_metadata=target_metadata
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=True,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
## Summary
- enable Alembic batch mode for SQLite
- use batch_alter_table to add policy_id column with foreign key

## Testing
- `alembic upgrade head`
- `sqlite3 app.db "PRAGMA table_info('users');"`
- `curl -X POST http://localhost:8001/login -H 'Content-Type: application/json' -d '{"username":"alice","password":"secret"}'`
- `pytest backend` *(fails: TypeError: string indices must be integers, not 'str', and other 401 assertions)*


------
https://chatgpt.com/codex/tasks/task_e_6890ba15eb60832ea1a4ea53427c5eb6