### PR TITLE
Add timeout and error handling for score request

### DIFF
--- a/scripts/stuffing.py
+++ b/scripts/stuffing.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from typing import Optional, Union
 
 
+REQUEST_TIMEOUT = 3
+
+
 def load_creds(path: Union[Path, str, None] = None, limit: Optional[int] = None):
     """Load credentials from a file with an optional limit.
 
@@ -120,7 +123,7 @@ def attack(
                 f"{score_base}/score",
                 json=score_payload,
                 headers=headers,
-                timeout=3,
+                timeout=REQUEST_TIMEOUT,
             )
             if score_resp.json().get("status") == "blocked":
                 blocked += 1
@@ -132,7 +135,7 @@ def attack(
                 except Exception as exc:
                     print("CHAIN ERROR:", exc)
         except requests.exceptions.RequestException as exc:
-            print("SCORE ERROR:", exc)
+            print(f"SCORE ERROR contacting {score_base}/score: {exc}")
 
         if login_ok:
             success += 1


### PR DESCRIPTION
## Summary
- add a constant timeout for the credential score request
- log and continue when the score service request fails

## Testing
- `python -m py_compile scripts/stuffing.py`


------
https://chatgpt.com/codex/tasks/task_e_6890c2ec67c0832ebce2c42aaf367e94