### PR TITLE
fix: compute wordlist path relative to script

### DIFF
--- a/scripts/stuffing.py
+++ b/scripts/stuffing.py
@@ -6,18 +6,20 @@ from pathlib import Path
 from typing import Optional, Union
 
 
-def load_creds(path: Union[Path, str, None] = None, limit: Optional[int] = None):
+# Location of the bundled password list used for credential stuffing attacks.
+# This uses ``__file__`` so the script works no matter the working directory.
+ROCKYOU_PATH = Path(__file__).with_name("data").joinpath("rockyou.txt")
+
+
+def load_creds(path: Union[Path, str] = ROCKYOU_PATH, limit: Optional[int] = None):
     """Load credentials from a file with an optional limit.
 
-    If *path* is not provided, the bundled ``rockyou.txt`` file located in the
-    ``data`` directory alongside this script will be used. Accepts either
-    ``Path`` objects or strings for *path*.
+    *path* may be a :class:`pathlib.Path` or string. By default the bundled
+    ``rockyou.txt`` file located in the ``data`` directory alongside this
+    script is used.
     """
 
-    if path is None:
-        path = Path(__file__).with_name("data").joinpath("rockyou.txt")
-    else:
-        path = Path(path)
+    path = Path(path)
 
     passwords = []
     with path.open(newline="", encoding="latin-1") as f:


### PR DESCRIPTION
## Summary
- use `Path(__file__)` to build path to bundled rockyou.txt wordlist
- simplify credential loader to always handle pathlib.Path values

## Testing
- `python -m py_compile scripts/stuffing.py`
- `python scripts/stuffing.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6890c2d7cea4832e966d716dd8518600