### PR TITLE
Use shared auth token key

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,8 @@
-import { useState } from "react";
-import { AUTH_TOKEN_KEY } from "./api";
 import { useState, useEffect } from "react";
-
+import {
+  AUTH_TOKEN_KEY,
+  logAuditEvent,
+} from "./api";
 import ScoreForm from "./ScoreForm";
 import AlertsTable from "./AlertsTable";
 import EventsTable from "./EventsTable";
@@ -12,28 +13,22 @@ import AttackSim from "./AttackSim";
 import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
 import "./App.css";
-import { TOKEN_KEY, logAuditEvent } from "./api";
 
 function App() {
   const [refreshKey, setRefreshKey] = useState(0);
   const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
 
-  const handleLogout = () => {
-    localStorage.removeItem(AUTH_TOKEN_KEY);
-  const [token, setToken] = useState(localStorage.getItem(TOKEN_KEY));
-  const [selectedUser, setSelectedUser] = useState("alice");
-
   const handleLogout = async () => {
     await logAuditEvent("user_logout");
-    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(AUTH_TOKEN_KEY);
     setToken(null);
   };
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const current = localStorage.getItem(TOKEN_KEY);
-      setToken(prev => (prev === current ? prev : current));
+      const current = localStorage.getItem(AUTH_TOKEN_KEY);
+      setToken((prev) => (prev === current ? prev : current));
     }, 1000);
     return () => clearInterval(interval);
   }, []);
@@ -53,10 +48,7 @@ function App() {
     <div className="app-container">
       <div className="header">
         <h1 className="dashboard-header">APIShield+ Dashboard</h1>
-        <button
-          className="logout-button"
-          onClick={handleLogout}
-        >
+        <button className="logout-button" onClick={handleLogout}>
           Logout
         </button>
       </div>
@@ -67,7 +59,10 @@ function App() {
         <LoginStatus token={token} />
       </div>
       <div className="dashboard-section">
-        <ScoreForm token={token} onNewAlert={() => setRefreshKey(k => k + 1)} />
+        <ScoreForm
+          token={token}
+          onNewAlert={() => setRefreshKey((k) => k + 1)}
+        />
       </div>
       <div className="dashboard-section">
         <AlertsChart token={token} />
@@ -91,3 +86,4 @@ function App() {
 }
 
 export default App;
+

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import { apiFetch, AUTH_TOKEN_KEY } from "./api";
-import { apiFetch, TOKEN_KEY, logAuditEvent } from "./api";
+import { apiFetch, AUTH_TOKEN_KEY, logAuditEvent } from "./api";
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
@@ -19,7 +18,6 @@ export default function LoginForm({ onLogin }) {
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
       localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
-      localStorage.setItem(TOKEN_KEY, data.access_token);
       await logAuditEvent("user_login_success");
       onLogin(data.access_token);
     } catch (err) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,11 +4,7 @@ export const API_KEY = process.env.REACT_APP_API_KEY || "";
 export const AUTH_TOKEN_KEY = "apiShieldAuthToken";
 
 export function logout() {
-  localStorage.removeItem(AUTH_TOKEN_KEY);
-export const TOKEN_KEY = "apiShieldAuthToken";
-
-export function logout() {
-  const token = localStorage.getItem(TOKEN_KEY);
+  const token = localStorage.getItem(AUTH_TOKEN_KEY);
   if (token) {
     fetch(`${API_BASE}/api/audit/log`, {
       method: "POST",
@@ -19,7 +15,7 @@ export function logout() {
       body: JSON.stringify({ event: "user_logout" }),
     }).catch(() => {});
   }
-  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(AUTH_TOKEN_KEY);
   window.location.reload();
 }
 
@@ -27,9 +23,10 @@ export async function apiFetch(path, options = {}) {
   const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
   const headers = { ...(options.headers || {}) };
   const token = localStorage.getItem(AUTH_TOKEN_KEY);
-  const token = localStorage.getItem(TOKEN_KEY);
   const skipAuth =
-    url.endsWith("/login") || url.endsWith("/register") || url.endsWith("/api/token");
+    url.endsWith("/login") ||
+    url.endsWith("/register") ||
+    url.endsWith("/api/token");
   if (token && !skipAuth && !headers["Authorization"]) {
     headers["Authorization"] = `Bearer ${token}`;
   }
@@ -69,3 +66,4 @@ export async function logAuditEvent(event) {
     console.error("audit log failed", err);
   }
 }
+

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -4,14 +4,10 @@ import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
 import { apiFetch, AUTH_TOKEN_KEY } from "../api";
 
-import { apiFetch, TOKEN_KEY } from "../api";
-
 function Dashboard() {
   const [ping, setPing] = useState(null);
   const [refresh, setRefresh] = useState(0);
   const token = localStorage.getItem(AUTH_TOKEN_KEY);
-
-  const token = localStorage.getItem(TOKEN_KEY);
 
   useEffect(() => {
     apiFetch("/ping")

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -1,7 +1,5 @@
 const API_BASE = 'http://localhost:3005';
 const AUTH_TOKEN_KEY = 'apiShieldAuthToken';
-
-const TOKEN_KEY = 'apiShieldAuthToken';
 const AUDIT_URL = 'http://localhost:8000/api/audit/log';
 
 let username = null;
@@ -16,7 +14,7 @@ async function fetchJSON(url, options = {}) {
   const { noAuth, ...opts } = options;
   const fetchOpts = { headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', ...opts };
   if (!noAuth) {
-    const token = localStorage.getItem(TOKEN_KEY);
+    const token = localStorage.getItem(AUTH_TOKEN_KEY);
     if (token) {
       fetchOpts.headers['Authorization'] = `Bearer ${token}`;
     }
@@ -38,7 +36,7 @@ async function fetchJSON(url, options = {}) {
 }
 
 async function logAuditEvent(event) {
-  const token = localStorage.getItem(TOKEN_KEY);
+  const token = localStorage.getItem(AUTH_TOKEN_KEY);
   const headers = { 'Content-Type': 'application/json' };
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
@@ -160,8 +158,7 @@ function showLogin() {
         body: JSON.stringify({ username, password: pw }),
         noAuth: true
       });
-      localStorage.setItem(AUTH_TOKEN_KEY, 'true');
-      localStorage.setItem(TOKEN_KEY, data.access_token);
+      localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
       await logAuditEvent('user_login_success');
       document.getElementById('loginBtn').style.display = 'none';
       document.getElementById('logoutBtn').style.display = 'inline-block';
@@ -242,7 +239,6 @@ async function logout() {
   }
   localStorage.removeItem(AUTH_TOKEN_KEY);
   await logAuditEvent('user_logout');
-  localStorage.removeItem(TOKEN_KEY);
   username = null;
   document.getElementById('loginBtn').style.display = 'inline-block';
   document.getElementById('logoutBtn').style.display = 'none';
@@ -283,9 +279,9 @@ function init() {
   checkSession();
 
   // Poll for token changes across tabs/apps
-  let lastToken = localStorage.getItem(TOKEN_KEY);
+  let lastToken = localStorage.getItem(AUTH_TOKEN_KEY);
   setInterval(() => {
-    const current = localStorage.getItem(TOKEN_KEY);
+    const current = localStorage.getItem(AUTH_TOKEN_KEY);
     if (current !== lastToken) {
       lastToken = current;
       checkSession();


### PR DESCRIPTION
## Summary
- Store the auth token under a single `apiShieldAuthToken` key and expose it via the shared API helper
- Update login, logout, and token polling in both frontend and shop-ui to read/write the shared key
- Simplify dashboard components to reference the unified key for authentication state

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c2b7fabc832eb8dc36429bdccd7f