### PR TITLE
Synchronize auth token across apps and add audit logging

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,3 @@
-import { useState } from "react";
-import { AUTH_TOKEN_KEY } from "./api";
 import { useState, useEffect } from "react";
 
 import ScoreForm from "./ScoreForm";
@@ -16,11 +14,6 @@ import { TOKEN_KEY, logAuditEvent } from "./api";
 
 function App() {
   const [refreshKey, setRefreshKey] = useState(0);
-  const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
-  const [selectedUser, setSelectedUser] = useState("alice");
-
-  const handleLogout = () => {
-    localStorage.removeItem(AUTH_TOKEN_KEY);
   const [token, setToken] = useState(localStorage.getItem(TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
 

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { apiFetch, AUTH_TOKEN_KEY } from "./api";
 import { apiFetch, TOKEN_KEY, logAuditEvent } from "./api";
 
 export default function LoginForm({ onLogin }) {
@@ -18,7 +17,6 @@ export default function LoginForm({ onLogin }) {
       });
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
-      localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
       localStorage.setItem(TOKEN_KEY, data.access_token);
       await logAuditEvent("user_login_success");
       onLogin(data.access_token);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,10 +1,6 @@
 export const API_BASE =
   process.env.REACT_APP_API_BASE || window.location.origin;
 export const API_KEY = process.env.REACT_APP_API_KEY || "";
-export const AUTH_TOKEN_KEY = "apiShieldAuthToken";
-
-export function logout() {
-  localStorage.removeItem(AUTH_TOKEN_KEY);
 export const TOKEN_KEY = "apiShieldAuthToken";
 
 export function logout() {
@@ -26,7 +22,6 @@ export function logout() {
 export async function apiFetch(path, options = {}) {
   const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
   const headers = { ...(options.headers || {}) };
-  const token = localStorage.getItem(AUTH_TOKEN_KEY);
   const token = localStorage.getItem(TOKEN_KEY);
   const skipAuth =
     url.endsWith("/login") || url.endsWith("/register") || url.endsWith("/api/token");

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,15 +2,11 @@
 import React, { useEffect, useState } from "react";
 import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
-import { apiFetch, AUTH_TOKEN_KEY } from "../api";
-
 import { apiFetch, TOKEN_KEY } from "../api";
 
 function Dashboard() {
   const [ping, setPing] = useState(null);
   const [refresh, setRefresh] = useState(0);
-  const token = localStorage.getItem(AUTH_TOKEN_KEY);
-
   const token = localStorage.getItem(TOKEN_KEY);
 
   useEffect(() => {

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -1,6 +1,4 @@
 const API_BASE = 'http://localhost:3005';
-const AUTH_TOKEN_KEY = 'apiShieldAuthToken';
-
 const TOKEN_KEY = 'apiShieldAuthToken';
 const AUDIT_URL = 'http://localhost:8000/api/audit/log';
 
@@ -160,7 +158,6 @@ function showLogin() {
         body: JSON.stringify({ username, password: pw }),
         noAuth: true
       });
-      localStorage.setItem(AUTH_TOKEN_KEY, 'true');
       localStorage.setItem(TOKEN_KEY, data.access_token);
       await logAuditEvent('user_login_success');
       document.getElementById('loginBtn').style.display = 'none';
@@ -170,7 +167,7 @@ function showLogin() {
     } catch (e) {
       showMessage('Login failed', true);
       username = null;
-      localStorage.removeItem(AUTH_TOKEN_KEY);
+      localStorage.removeItem(TOKEN_KEY);
     }
   });
   document.getElementById('registerLink').addEventListener('click', showRegister);
@@ -205,7 +202,7 @@ function showRegister() {
 
 // Determine whether the user already has an active session
 async function checkSession() {
-  if (!localStorage.getItem(AUTH_TOKEN_KEY)) {
+  if (!localStorage.getItem(TOKEN_KEY)) {
     username = null;
     document.getElementById('loginBtn').style.display = 'inline-block';
     document.getElementById('logoutBtn').style.display = 'none';
@@ -219,13 +216,13 @@ async function checkSession() {
       document.getElementById('loginBtn').style.display = 'none';
       document.getElementById('logoutBtn').style.display = 'inline-block';
     } else {
-      localStorage.removeItem(AUTH_TOKEN_KEY);
+      localStorage.removeItem(TOKEN_KEY);
       username = null;
       document.getElementById('loginBtn').style.display = 'inline-block';
       document.getElementById('logoutBtn').style.display = 'none';
     }
   } catch {
-    localStorage.removeItem(AUTH_TOKEN_KEY);
+    localStorage.removeItem(TOKEN_KEY);
     username = null;
     document.getElementById('loginBtn').style.display = 'inline-block';
     document.getElementById('logoutBtn').style.display = 'none';
@@ -240,7 +237,6 @@ async function logout() {
     showMessage('Logout failed', true);
     return;
   }
-  localStorage.removeItem(AUTH_TOKEN_KEY);
   await logAuditEvent('user_logout');
   localStorage.removeItem(TOKEN_KEY);
   username = null;


### PR DESCRIPTION
## Summary
- Share `apiShieldAuthToken` constant across dashboard and demo shop
- Send login/logout audit events to backend and attach token to requests
- Poll for token changes to keep apps in sync

## Testing
- `CI=true npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c29f5008832e96ffaa279e384a3d