### PR TITLE
Use CRA proxy when API base not specified

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,9 +6,13 @@ Refer to the root README for instructions on starting the shop.
 
 ## Environment Variables
 
-The frontend is preconfigured to talk to the demo shop backend running on
-`http://localhost:8001`. This base URL is provided via the
-`REACT_APP_API_BASE` variable in the `.env` file.
+The dashboard uses the `REACT_APP_API_BASE` environment variable to reach
+the backend API. It defaults to an empty string so Create React App's proxy
+can forward requests to the backend at `http://localhost:8001`.
+
+If your API runs on a different host or port, set `REACT_APP_API_BASE` in
+`frontend/.env` or provide it through your start script so the dashboard can
+locate the correct endpoint.
 
 ## Available Scripts
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,4 @@
-export const API_BASE =
-  process.env.REACT_APP_API_BASE || window.location.origin;
+export const API_BASE = process.env.REACT_APP_API_BASE || "";
 export const API_KEY = process.env.REACT_APP_API_KEY || "";
 export const AUTH_TOKEN_KEY = "apiShieldAuthToken";
 


### PR DESCRIPTION
## Summary
- default API_BASE to empty string to leverage CRA proxy
- document REACT_APP_API_BASE usage for non-default API locations

## Testing
- `npm test -- --watchAll=false` (fails: Identifier 'useState' has already been declared)
- `pytest`
- `curl -sS -D - http://localhost:8001/ping`
- `curl -sS -D - http://localhost:8001/api/alerts/`


------
https://chatgpt.com/codex/tasks/task_e_6890c27e8620832eb1e3581342d863bd