### PR TITLE
Handle optional auth header

### DIFF
--- a/frontend/src/AlertsTable.jsx
+++ b/frontend/src/AlertsTable.jsx
@@ -7,9 +7,8 @@ export default function AlertsTable({ refresh, token }) {
 
   const loadAlerts = async () => {
     try {
-      const resp = await apiFetch("/api/alerts", {
-        headers: { Authorization: `Bearer ${token}` }
-      });
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      const resp = await apiFetch("/api/alerts", { headers });
       if (!resp.ok) throw new Error(await resp.text());
       setAlerts(await resp.json());
     } catch (err) {


### PR DESCRIPTION
## Summary
- avoid sending Authorization header when no token exists in AlertsTable

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Identifier 'useState' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6890c2818964832e8ad7b25e01522826