### PR TITLE
Log logout events and failures

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -147,9 +147,11 @@ async def logout(
     current_user=Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
+    success = False
     try:
         revoke_token(token)
-        log_event(db, current_user.username, "logout", True)
+        success = True
     except Exception:
-        log_event(db, current_user.username, "logout", False)
+        pass
+    log_event(db, current_user.username, "logout", success)
     return {"detail": "Logged out"}


### PR DESCRIPTION
## Summary
- log logout success or failure after revoking token

## Testing
- `pytest backend/tests/test_auth.py::test_logout_revokes_token -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_6890c83f6594832eb75964e6e3a85056