### PR TITLE
feat: add audit logging endpoint

### DIFF
--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -1,21 +1,15 @@
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.core.db import get_db
-from app.core.events import log_event
+from app.crud.audit import create_audit_log
+from app.schemas.audit import AuditLogCreate
 
 router = APIRouter(prefix="/api/audit", tags=["audit"])
 
 
-class AuditLog(BaseModel):
-    event: str
-    username: str | None = None
-    success: bool = True
-
-
 @router.post("/log")
-def audit_log(log: AuditLog, db: Session = Depends(get_db)):
+def audit_log(log: AuditLogCreate, db: Session = Depends(get_db)):
     """Record an audit event from a frontend."""
-    log_event(db, log.username, log.event, log.success)
+    create_audit_log(db, log.username, log.event)
     return {"status": "logged"}

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -2,6 +2,7 @@ from .alerts import get_all_alerts
 from .users import get_user_by_username, create_user
 from .events import create_event, get_events
 from .policies import get_policy_by_id, create_policy, get_policy_for_user
+from .audit import create_audit_log
 
 __all__ = [
     "get_all_alerts",
@@ -12,4 +13,5 @@ __all__ = [
     "get_policy_by_id",
     "create_policy",
     "get_policy_for_user",
+    "create_audit_log",
 ]

--- a/backend/app/crud/audit.py
+++ b/backend/app/crud/audit.py
@@ -1,0 +1,10 @@
+from sqlalchemy.orm import Session
+from app.models.audit_logs import AuditLog
+
+
+def create_audit_log(db: Session, username: str | None, event: str) -> AuditLog:
+    log = AuditLog(username=username, event=event)
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return log

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,5 +3,6 @@ from .users import User
 from .events import Event
 from .access_logs import AccessLog
 from .policies import Policy
+from .audit_logs import AuditLog
 
-__all__ = ["Alert", "User", "Event", "AccessLog", "Policy"]
+__all__ = ["Alert", "User", "Event", "AccessLog", "Policy", "AuditLog"]

--- a/backend/app/models/audit_logs.py
+++ b/backend/app/models/audit_logs.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime
+from app.core.db import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, nullable=True, index=True)
+    event = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+
+class AuditLogCreate(BaseModel):
+    event: str
+    username: Optional[str] = None
+
+
+class AuditLogRead(AuditLogCreate):
+    id: int
+    timestamp: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -1,0 +1,28 @@
+import os
+
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+os.environ['SECRET_KEY'] = 'test-secret'
+
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.models.audit_logs import AuditLog  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_function(_):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def teardown_function(_):
+    SessionLocal().close()
+
+
+def test_audit_log_persists_event():
+    resp = client.post('/api/audit/log', json={'event': 'user_login_success', 'username': 'alice'})
+    assert resp.status_code == 200
+    with SessionLocal() as db:
+        rows = db.query(AuditLog).all()
+        assert any(r.event == 'user_login_success' and r.username == 'alice' for r in rows)

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -109,6 +109,15 @@ app.post('/login', async (req, res) => {
       } catch (e) {
         console.error('Score API call failed');
       }
+      try {
+        await axios.post(
+          `${API_BASE}/api/audit/log`,
+          { event: 'user_login_failure', username },
+          { timeout: API_TIMEOUT }
+        );
+      } catch (e) {
+        console.error('Audit log failed');
+      }
     }
     return res.status(401).json({ error: 'invalid credentials' });
   }
@@ -136,6 +145,15 @@ const apiResp = await axios.post(
     } catch (e) {
       console.error('Score API call failed');
     }
+    try {
+      await axios.post(
+        `${API_BASE}/api/audit/log`,
+        { event: 'user_login_success', username },
+        { timeout: API_TIMEOUT }
+      );
+    } catch (e) {
+      console.error('Audit log failed');
+    }
   }
   res.json({ status: 'ok' });
 });
@@ -153,6 +171,17 @@ app.post('/logout', async (req, res) => {
       );
     } catch (e) {
       console.error('Backend logout failed', e);
+    }
+  }
+  if (FORWARD_API) {
+    try {
+      await axios.post(
+        `${API_BASE}/api/audit/log`,
+        { event: 'user_logout', username: req.session.username },
+        { timeout: API_TIMEOUT }
+      );
+    } catch (e) {
+      console.error('Audit log failed', e);
     }
   }
   req.session.apiToken = null;

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { apiFetch, TOKEN_KEY, logAuditEvent } from "./api";
 
-import { apiFetch, AUTH_TOKEN_KEY, logAuditEvent } from "./api";
-
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -20,11 +18,10 @@ export default function LoginForm({ onLogin }) {
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
       localStorage.setItem(TOKEN_KEY, data.access_token);
-
-      localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
       await logAuditEvent("user_login_success");
       onLogin(data.access_token);
     } catch (err) {
+      await logAuditEvent("user_login_failure");
       setError(err.message);
     }
   };


### PR DESCRIPTION
## Summary
- add audit log table and CRUD helpers
- expose /api/audit/log endpoint to persist audit events
- log login/logout events from demo shop and React dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890c818150c832ea406a38f2d7ead54