### PR TITLE
feat: poll shared token

### DIFF
--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends
+from typing import List
+
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 from sqlalchemy.orm import Session
 
 from app.core.db import get_db
@@ -7,9 +9,34 @@ from app.schemas.audit import AuditLogCreate
 
 router = APIRouter(prefix="/api/audit", tags=["audit"])
 
+_listeners: List[WebSocket] = []
+
+
+@router.websocket("/ws")
+async def audit_ws(ws: WebSocket):
+    """Register a websocket to receive audit events."""
+    await ws.accept()
+    _listeners.append(ws)
+    try:
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        if ws in _listeners:
+            _listeners.remove(ws)
+
+
+async def _broadcast(event: str):
+    """Send an audit event to all listeners."""
+    for ws in list(_listeners):
+        try:
+            await ws.send_json({"event": event})
+        except Exception:
+            _listeners.remove(ws)
+
 
 @router.post("/log")
-def audit_log(log: AuditLogCreate, db: Session = Depends(get_db)):
-    """Record an audit event from a frontend."""
+async def audit_log(log: AuditLogCreate, db: Session = Depends(get_db)):
+    """Record an audit event from a frontend and broadcast to listeners."""
     create_audit_log(db, log.username, log.event)
+    await _broadcast(log.event)
     return {"status": "logged"}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,5 @@
 import { useState, useEffect } from "react";
-import {
-  AUTH_TOKEN_KEY,
-  logAuditEvent,
-} from "./api";
+import { AUTH_TOKEN_KEY, logAuditEvent } from "./api";
 import ScoreForm from "./ScoreForm";
 import AlertsTable from "./AlertsTable";
 import EventsTable from "./EventsTable";
@@ -13,13 +10,12 @@ import AttackSim from "./AttackSim";
 import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
 import "./App.css";
-import { AUTH_TOKEN_KEY, logAuditEvent } from "./api";
 
 function App() {
   const [refreshKey, setRefreshKey] = useState(0);
-  const [token, setToken] = useState(localStorage.getItem(TOKEN_KEY));
-
-  const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
+  const [token, setToken] = useState(
+    localStorage.getItem(AUTH_TOKEN_KEY)
+  );
   const [selectedUser, setSelectedUser] = useState("alice");
 
   const handleLogout = async () => {
@@ -31,11 +27,15 @@ function App() {
   useEffect(() => {
     const interval = setInterval(() => {
       const current = localStorage.getItem(AUTH_TOKEN_KEY);
-      setToken(prev => (prev === current ? prev : current));
       setToken((prev) => (prev === current ? prev : current));
     }, 1000);
     return () => clearInterval(interval);
   }, []);
+
+  // Refresh tables when auth status changes
+  useEffect(() => {
+    setRefreshKey((k) => k + 1);
+  }, [token]);
 
   if (!token) {
     return (

--- a/frontend/src/LoginStatus.jsx
+++ b/frontend/src/LoginStatus.jsx
@@ -18,9 +18,11 @@ export default function LoginStatus({ token }) {
   };
 
   useEffect(() => {
-    load();
+    if (token) {
+      load();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [token]);
 
   if (error) return <p className="error-text">{error}</p>;
   if (Object.keys(logins).length === 0) return <p>No login data.</p>;


### PR DESCRIPTION
## Summary
- poll shared auth token in React dashboard and refresh stats on change
- reload login status list whenever the auth token updates
- add websocket broadcasting for audit events

## Testing
- `cd backend && pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6890cbd7c6d0832e83c74e897e540a4d