### PR TITLE
docs: note API base configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,27 +131,11 @@ Prometheus metrics will be exposed at `http://localhost:8001/metrics`.
 
 ```bash
 cd frontend
-npm install 
-
-# if there is an error re-run the command with the below command this is because linux runs commands differently to windows which is why there may be an error
-npm install --save-dev cross-env
-
-# If there is still an error go to the package-lock.json and input this code to hard-code the URL into the react-development server 
-"scripts": 
-{
-"start": "cross-env REACT_APP_API_BASE=http://localhost:8001 react-scripts start",
-"build": "cross-env REACT_APP_API_BASE=http://localhost:8001 react-scripts build",
-"test": "cross-env REACT_APP_API_BASE=http://localhost:8001 react-scripts test",
-  "eject": "react-scripts eject"
-}
-# once this is done then 
+npm install
 npm start
 ```
 
-The start script sets `REACT_APP_API_BASE` to `http://localhost:8001`. Override
-this variable when building or running the frontend if the API lives at a
-different URL. Set `REACT_APP_API_KEY` if the backend requires an `X-API-Key`
-header.
+The dashboard uses the `REACT_APP_API_BASE` environment variable to reach the backend API. By default, requests are proxied to `http://localhost:8001`. If your API runs on a different host or port, set `REACT_APP_API_BASE` in `frontend/.env` or when starting the app (e.g., `REACT_APP_API_BASE=https://api.example.com npm start`). Set `REACT_APP_API_KEY` if the backend requires an `X-API-Key` header.
 
 The React application will be available at [http://localhost:3000](http://localhost:3000).
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,5 @@
-REACT_APP_API_BASE=http://localhost:8001
+# Base URL for the backend API.
+# Leave unset to allow Create React App's proxy to reach http://localhost:8001.
+# If the API runs elsewhere, set REACT_APP_API_BASE to the full URL, e.g.:
+# REACT_APP_API_BASE=https://api.example.com
+# REACT_APP_API_BASE=http://localhost:8001

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,3 +1,4 @@
+// Base URL for the backend API. If unset, requests use relative paths and rely on CRA's proxy.
 export const API_BASE = process.env.REACT_APP_API_BASE || "";
 export const API_KEY = process.env.REACT_APP_API_KEY || "";
 export const AUTH_TOKEN_KEY = "apiShieldAuthToken";


### PR DESCRIPTION
## Summary
- clarify API base usage in frontend
- explain setting `REACT_APP_API_BASE` for alternative backends

## Testing
- `CI=true npm test` *(fails: Identifier 'AUTH_TOKEN_KEY' has already been declared)*
- `DATABASE_URL=sqlite:///./app.db SECRET_KEY=devkey pytest`
- `REACT_APP_API_BASE=http://localhost:8001 node --input-type=module <<'NODE'\nimport { apiFetch } from './frontend/src/api.js';\nglobal.localStorage = { getItem: () => null, removeItem: () => {} };\nconst r1 = await apiFetch('/ping');\nconsole.log('ping', r1.status, await r1.text());\nconst r2 = await apiFetch('/api/alerts/');\nconsole.log('alerts', r2.status, await r2.text());\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_6890cbc4763c832e8c5c7a45534956d9