### PR TITLE
Simplify cart fetch and cleanup dashboard imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ server starts your default browser opens the shop home page automatically at
    account displays how secure it is as a progress bar and lists the enabled
    protections. Alice intentionally has reduced security while Ben has all
    security features enabled. When a login succeeds the simulator fetches the
-   user's cart and orders from Demo Shop, demonstrating how Alice's data is
-   exposed while Ben remains safe.
+  user's cart from Demo Shop, demonstrating how Alice's data is exposed while
+  Ben remains safe.
 
 
 2. Log in and locate the **Credential Stuffing Simulation** section. Choose a

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,13 +13,12 @@ import AttackSim from "./AttackSim";
 import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
 import "./App.css";
-import { AUTH_TOKEN_KEY, logAuditEvent } from "./api";
 
 function App() {
   const [refreshKey, setRefreshKey] = useState(0);
-  const [token, setToken] = useState(localStorage.getItem(TOKEN_KEY));
-
-  const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
+  const [token, setToken] = useState(
+    localStorage.getItem(AUTH_TOKEN_KEY)
+  );
   const [selectedUser, setSelectedUser] = useState("alice");
 
   const handleLogout = async () => {
@@ -31,7 +30,6 @@ function App() {
   useEffect(() => {
     const interval = setInterval(() => {
       const current = localStorage.getItem(AUTH_TOKEN_KEY);
-      setToken(prev => (prev === current ? prev : current));
       setToken((prev) => (prev === current ? prev : current));
     }, 1000);
     return () => clearInterval(interval);

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -247,9 +247,12 @@ export default function AttackSim({ user }) {
                 </p>
               )}
               {results.first_cart && (
-                <p>
-                  Cart <code>{JSON.stringify(results.first_cart)}</code>
-                </p>
+                <div>
+                  <p>Cart</p>
+                  <pre>
+                    <code>{JSON.stringify(results.first_cart, null, 2)}</code>
+                  </pre>
+                </div>
               )}
             </>
           )}


### PR DESCRIPTION
## Summary
- render cart contents from demo shop without orders in AttackSim
- clarify credential-stuffing demo description to mention only carts
- clean up dashboard App component to use a single auth token key

## Testing
- `npm test -- --watchAll=false`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890cbed0448832ea3dc64cb244e8bd1