### PR TITLE
feat: forward failed logins to api

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -84,18 +84,14 @@ app.post('/login', async (req, res) => {
   const { username, password } = req.body;
   if (!users[username] || users[username].password !== password) {
     if (FORWARD_API) {
-      try {
-        await axios.post(
-          `${API_BASE}/login`,
-          { username, password },
-          { timeout: API_TIMEOUT }
-        );
-      } catch (e) {
-        // Ignore expected 401 but surface other errors
-        if (e.response?.status !== 401) {
-          console.error('Login API call failed');
-        }
-      }
+      await axios
+        .post(`${API_BASE}/login`, { username, password }, { timeout: API_TIMEOUT })
+        .catch((e) => {
+          // Ignore expected 401 but surface other errors
+          if (e.response?.status !== 401) {
+            console.error('Login API call failed', e);
+          }
+        });
       try {
         await axios.post(
           `${API_BASE}/score`,


### PR DESCRIPTION
## Summary
- forward invalid login attempts to backend and ignore expected 401s

## Testing
- `cd demo-shop && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890fcc0c24c832eb804642d684b4cd8