### PR TITLE
chore: streamline auth token sync

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,14 +23,6 @@ function App() {
     setToken(null);
   };
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      const current = localStorage.getItem(AUTH_TOKEN_KEY);
-      setToken((prev) => (prev === current ? prev : current));
-    }, 1000);
-    return () => clearInterval(interval);
-  }, []);
-
   // Refresh tables when auth status changes
   useEffect(() => {
     setRefreshKey((k) => k + 1);


### PR DESCRIPTION
## Summary
- remove redundant token polling in App component
- rely on AUTH_TOKEN_KEY for initial token state and refresh only on changes

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6890fd1edabc832ea964e90e2a2401a7