### PR TITLE
Log out via API before session destruction

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -164,21 +164,21 @@ const apiResp = await axios.post(
 });
 
 app.post('/logout', async (req, res) => {
-  if (FORWARD_API && req.session.apiToken) {
-    try {
-      await axios.post(
-        `${API_BASE}/logout`,
-        null,
-        {
-          headers: { Authorization: `Bearer ${req.session.apiToken}` },
-          timeout: API_TIMEOUT,
-        }
-      );
-    } catch (e) {
-      console.error('Backend logout failed', e);
-    }
-  }
   if (FORWARD_API) {
+    if (req.session.apiToken) {
+      try {
+        await axios.post(
+          `${API_BASE}/logout`,
+          null,
+          {
+            headers: { Authorization: `Bearer ${req.session.apiToken}` },
+            timeout: API_TIMEOUT,
+          }
+        );
+      } catch (e) {
+        console.error('Backend logout failed', e);
+      }
+    }
     try {
       await axios.post(
         `${API_BASE}/api/audit/log`,


### PR DESCRIPTION
## Summary
- Ensure demo-shop forwards logout to backend when FORWARD_API is enabled.
- Call backend logout with API token and log any failures before destroying session.

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689102a2df44832eb28e44de39adac52