### PR TITLE
chore: poll for auth token changes across UIs

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,15 @@ function App() {
   const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
 
+  // Poll for token changes across tabs/apps
+  useEffect(() => {
+    const id = setInterval(() => {
+      const stored = localStorage.getItem(AUTH_TOKEN_KEY);
+      setToken((prev) => (prev !== stored ? stored : prev));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
   const handleLogout = async () => {
     const username = localStorage.getItem(USERNAME_KEY);
     await logAuditEvent("user_logout", username);

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -281,13 +281,17 @@ function init() {
   loadProducts();
   checkSession();
 
-  // Poll for token changes across tabs/apps
+  // Poll for token changes across tabs/apps and refresh UI
   let lastToken = localStorage.getItem(AUTH_TOKEN_KEY);
   setInterval(() => {
     const current = localStorage.getItem(AUTH_TOKEN_KEY);
     if (current !== lastToken) {
       lastToken = current;
       checkSession();
+      // If the stats view is active, refresh it
+      if (document.querySelector('.stats-list')) {
+        viewStats();
+      }
     }
   }, 1000);
 }


### PR DESCRIPTION
## Summary
- poll React dashboard for token changes and refresh state
- poll shop UI for shared token updates and refresh stats

## Testing
- `cd frontend && npm test -- --watchAll=false`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_689102d355c0832eb84be50a935333e3