### PR TITLE
Remove legacy token key and unify logout

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { AUTH_TOKEN_KEY, USERNAME_KEY, logAuditEvent } from "./api";
+import { AUTH_TOKEN_KEY, logout } from "./api";
 import ScoreForm from "./ScoreForm";
 import AlertsTable from "./AlertsTable";
 import EventsTable from "./EventsTable";
@@ -16,16 +16,6 @@ function App() {
 
   const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
-
-  const handleLogout = async () => {
-    const username = localStorage.getItem(USERNAME_KEY);
-    await logAuditEvent("user_logout", username);
-    localStorage.removeItem(AUTH_TOKEN_KEY);
-    if (username) {
-      localStorage.removeItem(USERNAME_KEY);
-    }
-    setToken(null);
-  };
 
   // Refresh tables when auth status changes
   useEffect(() => {
@@ -48,7 +38,7 @@ function App() {
       {/* Dashboard title and logout */}
       <div className="header">
         <h1 className="dashboard-header">APIShield+ Dashboard</h1>
-        <button className="logout-button" onClick={handleLogout}>Logout</button>
+        <button className="logout-button" onClick={logout}>Logout</button>
       </div>
       <div className="dashboard-section">
         <UserAccounts onSelect={setSelectedUser} />

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { apiFetch, TOKEN_KEY, USERNAME_KEY, logAuditEvent } from "./api";
+import { apiFetch, AUTH_TOKEN_KEY, USERNAME_KEY, logAuditEvent } from "./api";
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
@@ -17,7 +17,7 @@ export default function LoginForm({ onLogin }) {
       });
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
-      localStorage.setItem(TOKEN_KEY, data.access_token);
+      localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
       localStorage.setItem(USERNAME_KEY, username);
       await logAuditEvent("user_login_success", username);
       onLogin(data.access_token);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,8 +2,6 @@
 export const API_BASE = process.env.REACT_APP_API_BASE || "";
 export const API_KEY = process.env.REACT_APP_API_KEY || "";
 export const AUTH_TOKEN_KEY = "apiShieldAuthToken";
-// Maintain legacy name for compatibility
-export const TOKEN_KEY = AUTH_TOKEN_KEY;
 export const USERNAME_KEY = "apiShieldUsername";
 
 export async function logAuditEvent(event, username) {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,15 +2,11 @@
 import React, { useEffect, useState } from "react";
 import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
-import { apiFetch, TOKEN_KEY } from "../api";
-
 import { apiFetch, AUTH_TOKEN_KEY } from "../api";
 
 function Dashboard() {
   const [ping, setPing] = useState(null);
   const [refresh, setRefresh] = useState(0);
-  const token = localStorage.getItem(TOKEN_KEY);
-
   const token = localStorage.getItem(AUTH_TOKEN_KEY);
 
   useEffect(() => {

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -1,6 +1,4 @@
 const API_BASE = 'http://localhost:3005';
-const TOKEN_KEY = 'apiShieldAuthToken';
-
 const AUTH_TOKEN_KEY = 'apiShieldAuthToken';
 const AUDIT_URL = 'http://localhost:8000/api/audit/log';
 
@@ -160,8 +158,6 @@ function showLogin() {
         body: JSON.stringify({ username, password: pw }),
         noAuth: true
       });
-      localStorage.setItem(TOKEN_KEY, data.access_token);
-
       localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
       await logAuditEvent('user_login_success');
       document.getElementById('loginBtn').style.display = 'none';
@@ -171,7 +167,7 @@ function showLogin() {
     } catch (e) {
       showMessage('Login failed', true);
       username = null;
-      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(AUTH_TOKEN_KEY);
     }
   });
   document.getElementById('registerLink').addEventListener('click', showRegister);
@@ -206,7 +202,7 @@ function showRegister() {
 
 // Determine whether the user already has an active session
 async function checkSession() {
-  if (!localStorage.getItem(TOKEN_KEY)) {
+  if (!localStorage.getItem(AUTH_TOKEN_KEY)) {
     username = null;
     document.getElementById('loginBtn').style.display = 'inline-block';
     document.getElementById('logoutBtn').style.display = 'none';
@@ -220,13 +216,13 @@ async function checkSession() {
       document.getElementById('loginBtn').style.display = 'none';
       document.getElementById('logoutBtn').style.display = 'inline-block';
     } else {
-      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(AUTH_TOKEN_KEY);
       username = null;
       document.getElementById('loginBtn').style.display = 'inline-block';
       document.getElementById('logoutBtn').style.display = 'none';
     }
   } catch {
-    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(AUTH_TOKEN_KEY);
     username = null;
     document.getElementById('loginBtn').style.display = 'inline-block';
     document.getElementById('logoutBtn').style.display = 'none';


### PR DESCRIPTION
## Summary
- Drop `TOKEN_KEY` alias and export only `AUTH_TOKEN_KEY`
- Update login and dashboard to use `AUTH_TOKEN_KEY` exclusively
- Use shared `logout` helper and remove duplicate implementations

## Testing
- `cd frontend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689102de47a8832e80161775bf0e669d