### PR TITLE
refactor: simplify login token storage

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { apiFetch, AUTH_TOKEN_KEY, USERNAME_KEY, logAuditEvent } from "./api";
+import { apiFetch, AUTH_TOKEN_KEY, logAuditEvent } from "./api";
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
@@ -18,7 +18,6 @@ export default function LoginForm({ onLogin }) {
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
       localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
-      localStorage.setItem(USERNAME_KEY, username);
       await logAuditEvent("user_login_success", username);
       onLogin(data.access_token);
     } catch (err) {


### PR DESCRIPTION
## Summary
- simplify LoginForm imports to only use AUTH_TOKEN_KEY
- store just the auth token in local storage on login

## Testing
- `cd frontend && npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689107667be0832eba15a13b971873f9