### PR TITLE
chore: clarify token retrieval

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,4 +1,3 @@
-// frontend/src/pages/Dashboard.jsx
 import React, { useEffect, useState } from "react";
 import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
@@ -7,6 +6,7 @@ import { apiFetch, AUTH_TOKEN_KEY } from "../api";
 function Dashboard() {
   const [ping, setPing] = useState(null);
   const [refresh, setRefresh] = useState(0);
+  // Retrieve the authentication token for API requests
   const token = localStorage.getItem(AUTH_TOKEN_KEY);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- clarify how Dashboard retrieves the auth token

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68910c35e684832e8ce905523f768b20