### PR TITLE
refactor: use shared settings instance in db

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -5,10 +5,7 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-from app.core.config import Settings
-
-# pull your DATABASE_URL from settings
-settings = Settings()
+from app.core.config import settings
 
 # create SQLAlchemy engine
 _echo_env = os.getenv("DB_ECHO", "false").lower()


### PR DESCRIPTION
## Summary
- import shared `settings` instead of instantiating `Settings` in `db`
- rely on single configuration object for database connection

## Testing
- `flake8 backend/app/core/db.py`
- `pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68911b17b9e8832e8c362ebe0c9941db