### PR TITLE
Use dialect-aware time bucketing for alert stats

### DIFF
--- a/backend/app/api/alerts.py
+++ b/backend/app/api/alerts.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func, case
 
 from app.core.db import get_db
+from app.core.time_buckets import bucket_time
 from app.crud.alerts import get_all_alerts
 from app.schemas.alerts import AlertRead, AlertStat
 from app.api.dependencies import get_current_user
@@ -26,9 +27,10 @@ def read_alert_stats(
     _user: dict = Depends(get_current_user),
 ):
     """Aggregate alert counts per minute."""
+    time_expr = bucket_time(Alert.timestamp, db.get_bind().dialect.name)
     rows = (
         db.query(
-            func.strftime("%Y-%m-%d %H:%M:00", Alert.timestamp).label("time"),
+            time_expr.label("time"),
             func.sum(
                 case((Alert.detail == "Blocked: too many failures", 1), else_=0)
             ).label("blocked"),
@@ -36,8 +38,8 @@ def read_alert_stats(
                 case((Alert.detail != "Blocked: too many failures", 1), else_=0)
             ).label("invalid"),
         )
-        .group_by("time")
-        .order_by("time")
+        .group_by(time_expr)
+        .order_by(time_expr)
         .all()
     )
     return [

--- a/backend/app/core/time_buckets.py
+++ b/backend/app/core/time_buckets.py
@@ -1,0 +1,15 @@
+from sqlalchemy import func
+from sqlalchemy.sql import ColumnElement
+
+
+def bucket_time(column: ColumnElement, dialect_name: str, interval: str = "minute"):
+    """Return expression that truncates *column* to a time bucket.
+
+    Currently supports minute-level bucketing. Uses SQLite's strftime when the
+    active dialect is SQLite and ``date_trunc`` otherwise (e.g., PostgreSQL).
+    """
+    if interval != "minute":
+        raise ValueError("Only minute interval is supported")
+    if dialect_name == "sqlite":
+        return func.strftime("%Y-%m-%d %H:%M:00", column)
+    return func.date_trunc("minute", column)

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -5,11 +5,13 @@ os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy.dialects import postgresql, sqlite  # noqa: E402
 from app.main import app  # noqa: E402
 from app.core.db import Base, engine, SessionLocal  # noqa: E402
 from app.models.alerts import Alert  # noqa: E402
 from app.core.security import create_access_token, get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
+from app.core.time_buckets import bucket_time  # noqa: E402
 
 client = TestClient(app)
 
@@ -51,3 +53,13 @@ def test_stats_endpoint():
     assert len(data) == 2
     assert data[0]['invalid'] == 1
     assert data[1]['blocked'] == 1
+
+
+def test_bucket_time_generates_sql():
+    expr_sqlite = bucket_time(Alert.timestamp, 'sqlite')
+    sql_sqlite = str(expr_sqlite.compile(dialect=sqlite.dialect()))
+    assert 'strftime' in sql_sqlite
+
+    expr_pg = bucket_time(Alert.timestamp, 'postgresql')
+    sql_pg = str(expr_pg.compile(dialect=postgresql.dialect()))
+    assert 'date_trunc' in sql_pg


### PR DESCRIPTION
## Summary
- add `bucket_time` helper selecting `strftime` for SQLite and `date_trunc` elsewhere
- use helper in alert stats query for portable time bucketing
- test SQL generation for SQLite and PostgreSQL dialects

## Testing
- `flake8 backend/app/api/alerts.py backend/app/core/time_buckets.py backend/tests/test_stats.py`
- `pytest backend/tests/test_stats.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68911b19d808832e9640f5be79ee7786