### PR TITLE
feat: bypass risk checks for auth endpoints

### DIFF
--- a/backend/app/core/policy.py
+++ b/backend/app/core/policy.py
@@ -9,6 +9,8 @@ from app.models.alerts import Alert
 
 FAIL_LIMIT = int(os.getenv("FAIL_LIMIT", 5))
 FAIL_WINDOW_SECONDS = int(os.getenv("FAIL_WINDOW_SECONDS", 60))
+# Paths that bypass policy engine risk checks
+EXEMPT_PATHS = {"/score", "/register", "/login"}
 
 
 def assess_risk(db: Session, request: Request) -> bool:
@@ -31,7 +33,7 @@ class PolicyEngineMiddleware:
             await self.app(scope, receive, send)
             return
         request = Request(scope, receive=receive)
-        if request.url.path in {"/score", "/register", "/login"}:
+        if request.url.path in EXEMPT_PATHS:
             await self.app(scope, receive, send)
             return
         # Create DB session lazily to avoid overhead

--- a/backend/tests/test_policy_engine_middleware.py
+++ b/backend/tests/test_policy_engine_middleware.py
@@ -4,6 +4,7 @@ import os
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
+import pytest
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
 from app.core.db import Base, engine, SessionLocal  # noqa: E402
@@ -25,19 +26,20 @@ def teardown_function(_):
     SessionLocal().close()
 
 
-def test_register_and_login_not_blocked_by_policy_engine():
-    # Confirm other endpoints are blocked
+@pytest.mark.parametrize("endpoint", ["/register", "/login"])
+def test_auth_endpoints_bypass_policy_engine(endpoint):
+    if endpoint == "/login":
+        client.post('/register', json={'username': 'newuser', 'password': 'pw'})
+    resp = client.post(endpoint, json={'username': 'newuser', 'password': 'pw'})
+    assert resp.status_code == 200
+
+
+def test_policy_engine_blocks_other_endpoints():
     resp = client.get('/ping')
     assert resp.status_code == 403
 
-    # /register should bypass policy engine
-    resp = client.post('/register', json={'username': 'newuser', 'password': 'pw'})
-    assert resp.status_code == 200
 
-    # /login should also bypass policy engine
-    resp = client.post('/login', json={'username': 'newuser', 'password': 'pw'})
-    assert resp.status_code == 200
-
-    # Failed login should return 401, not 403
+def test_failed_login_returns_401_not_403():
+    client.post('/register', json={'username': 'newuser', 'password': 'pw'})
     resp = client.post('/login', json={'username': 'newuser', 'password': 'wrong'})
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- exempt /register and /login from policy engine risk checks
- cover auth endpoints with middleware tests

## Testing
- `pytest backend/tests/test_policy_engine_middleware.py -q -p no:warnings`


------
https://chatgpt.com/codex/tasks/task_e_68911b20c670832e87cf4e8a74a9c896