### PR TITLE
Persist security chain state in database

### DIFF
--- a/backend/app/api/score.py
+++ b/backend/app/api/score.py
@@ -106,7 +106,7 @@ def record_attempt(
             attempts = attempts[-fail_limit:]
         FAILED_USER_ATTEMPTS[user_id] = attempts
 
-    if security.SECURITY_ENABLED and fail_count >= ip_fail_limit:
+    if security.is_enabled(db) and fail_count >= ip_fail_limit:
         STUFFING_DETECTIONS.labels(ip=client_ip).inc()
         alert = Alert(
             ip_address=client_ip,
@@ -143,8 +143,8 @@ def score(payload: Dict[str, Any], request: Request, db: Session = Depends(get_d
     time window. The defaults are 5 failures within 60 seconds but can be adjusted
     via the FAIL_LIMIT and FAIL_WINDOW_SECONDS environment variables.
     """
-    if security.SECURITY_ENABLED:
-        security.verify_chain(request.headers.get("X-Chain-Password"))
+    if security.is_enabled(db):
+        security.verify_chain(request.headers.get("X-Chain-Password"), db)
 
     client_ip = payload.get("client_ip")
     auth_result = payload.get("auth_result")

--- a/backend/app/api/security.py
+++ b/backend/app/api/security.py
@@ -1,17 +1,15 @@
 from fastapi import APIRouter, HTTPException, Depends
 import hashlib
 import secrets
+from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.api.dependencies import require_role
+from app.core.db import get_db
+from app.models.security import SecurityState
 
-# Global flag controlling credential stuffing enforcement
-SECURITY_ENABLED = True
 
-# Password chain used when SECURITY_ENABLED is True. Each API call must present
-# the current value which is then rotated. This helps detect replayed or stale
-# requests.
-CURRENT_CHAIN = None
+router = APIRouter(prefix="/api/security", tags=["security"])
 
 
 def _hash(value: str) -> str:
@@ -24,55 +22,66 @@ def _new_chain(prev: str | None = None) -> str:
     return _hash(seed + secrets.token_hex(8))
 
 
-def init_chain() -> None:
-    """Initialise the global chain value."""
-    global CURRENT_CHAIN
-    CURRENT_CHAIN = _new_chain()
+def get_state(db: Session) -> SecurityState:
+    """Fetch the singleton ``SecurityState`` row, creating it if missing."""
+    state = db.query(SecurityState).first()
+    if state is None:
+        state = SecurityState(security_enabled=True, current_chain=_new_chain())
+        db.add(state)
+        db.commit()
+        db.refresh(state)
+    return state
 
 
-def rotate_chain() -> None:
+def init_chain(db: Session) -> None:
+    """Initialise the chain value in the shared store."""
+    state = get_state(db)
+    state.current_chain = _new_chain()
+    db.commit()
+
+
+def rotate_chain(db: Session) -> None:
     """Advance the chain to the next value."""
-    global CURRENT_CHAIN
-    CURRENT_CHAIN = _new_chain(CURRENT_CHAIN)
+    state = get_state(db)
+    state.current_chain = _new_chain(state.current_chain)
+    db.commit()
 
 
-def verify_chain(token: str | None) -> None:
+def verify_chain(token: str | None, db: Session) -> None:
     """Validate ``token`` matches the current chain and rotate."""
-    if token != CURRENT_CHAIN:
+    state = get_state(db)
+    if token != state.current_chain:
         raise HTTPException(status_code=401, detail="Invalid chain token")
-    rotate_chain()
+    rotate_chain(db)
 
 
-# initialise chain on import so it's ready when the app starts
-init_chain()
-
-router = APIRouter(prefix="/api/security", tags=["security"])
+def is_enabled(db: Session) -> bool:
+    return get_state(db).security_enabled
 
 
 @router.get("/")
-def get_security(_user=Depends(require_role("admin"))):
+def get_security(_user=Depends(require_role("admin")), db: Session = Depends(get_db)):
     """Return current security enforcement state."""
-    return {"enabled": SECURITY_ENABLED}
+    return {"enabled": get_state(db).security_enabled}
 
 
 @router.get("/chain")
-def get_chain(_user=Depends(require_role("admin"))):
+def get_chain(_user=Depends(require_role("admin")), db: Session = Depends(get_db)):
     """Retrieve the current chain value."""
-    return {"chain": CURRENT_CHAIN}
+    return {"chain": get_state(db).current_chain}
 
 
 @router.post("/")
-def set_security(payload: dict, _user=Depends(require_role("admin"))):
+def set_security(payload: dict, _user=Depends(require_role("admin")), db: Session = Depends(get_db)):
     """Update security enforcement state."""
     enabled = payload.get("enabled")
     if not isinstance(enabled, bool):
         raise HTTPException(status_code=422, detail="'enabled' boolean required")
-    global SECURITY_ENABLED
-    SECURITY_ENABLED = enabled
+    state = get_state(db)
+    state.security_enabled = enabled
     if enabled:
-        init_chain()
+        state.current_chain = _new_chain()
     else:
-        # Clear chain when security disabled
-        global CURRENT_CHAIN
-        CURRENT_CHAIN = None
-    return {"enabled": SECURITY_ENABLED}
+        state.current_chain = None
+    db.commit()
+    return {"enabled": state.security_enabled}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,5 +4,14 @@ from .events import Event
 from .access_logs import AccessLog
 from .policies import Policy
 from .audit_logs import AuditLog
+from .security import SecurityState
 
-__all__ = ["Alert", "User", "Event", "AccessLog", "Policy", "AuditLog"]
+__all__ = [
+    "Alert",
+    "User",
+    "Event",
+    "AccessLog",
+    "Policy",
+    "AuditLog",
+    "SecurityState",
+]

--- a/backend/app/models/security.py
+++ b/backend/app/models/security.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, Boolean, String
+
+from app.core.db import Base
+
+
+class SecurityState(Base):
+    """Singleton table storing security enable flag and chain value."""
+    __tablename__ = "security_state"
+
+    id = Column(Integer, primary_key=True, index=True)
+    security_enabled = Column(Boolean, nullable=False, default=True)
+    current_chain = Column(String, nullable=True)

--- a/backend/tests/test_score.py
+++ b/backend/tests/test_score.py
@@ -15,14 +15,14 @@ from app.core.security import get_password_hash  # noqa: E402
 client = TestClient(app)
 
 
-def _auth_headers():
-    resp = client.post('/login', json={'username': 'admin', 'password': 'pw'})
+def _auth_headers(c):
+    resp = c.post('/login', json={'username': 'admin', 'password': 'pw'})
     token = resp.json()['access_token']
     return {'Authorization': f'Bearer {token}'}
 
 
-def current_chain():
-    return client.get('/api/security/chain', headers=_auth_headers()).json()['chain']
+def current_chain(c=client):
+    return c.get('/api/security/chain', headers=_auth_headers(c)).json()['chain']
 
 
 def setup_function(_):

--- a/backend/tests/test_security_toggle.py
+++ b/backend/tests/test_security_toggle.py
@@ -16,15 +16,12 @@ client = TestClient(app)
 def setup_function(_):
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
-    # reset flag for each test
-    from app.api import security
-    security.SECURITY_ENABLED = True
     with SessionLocal() as db:
         create_user(db, username="admin", password_hash=get_password_hash("pw"), role="admin")
 
 
-def _auth_headers():
-    resp = client.post('/login', json={'username': 'admin', 'password': 'pw'})
+def _auth_headers(c):
+    resp = c.post('/login', json={'username': 'admin', 'password': 'pw'})
     token = resp.json()['access_token']
     return {'Authorization': f'Bearer {token}'}
 
@@ -34,25 +31,47 @@ def teardown_function(_):
 
 
 def test_get_security_default():
-    resp = client.get('/api/security', headers=_auth_headers())
+    resp = client.get('/api/security', headers=_auth_headers(client))
     assert resp.status_code == 200
     assert resp.json()['enabled'] is True
 
 
 def test_toggle_security():
-    resp = client.post('/api/security', json={'enabled': False}, headers=_auth_headers())
+    resp = client.post('/api/security', json={'enabled': False}, headers=_auth_headers(client))
     assert resp.status_code == 200
     assert resp.json()['enabled'] is False
-    resp = client.get('/api/security', headers=_auth_headers())
+    # New client should see the same state
+    other = TestClient(app)
+    resp = other.get('/api/security', headers=_auth_headers(other))
     assert resp.json()['enabled'] is False
 
 
 def test_score_not_blocked_when_disabled():
     # disable security
-    client.post('/api/security', json={'enabled': False}, headers=_auth_headers())
+    client.post('/api/security', json={'enabled': False}, headers=_auth_headers(client))
     # Send failures exceeding threshold
     for i in range(6):
         resp = client.post('/score', json={'client_ip': '9.9.9.9', 'auth_result': 'failure'})
         assert resp.status_code == 200
         # should never be blocked
         assert resp.json()['status'] == 'ok'
+
+
+def test_chain_persists_across_clients():
+    chain = client.get('/api/security/chain', headers=_auth_headers(client)).json()['chain']
+    resp = client.post(
+        '/score',
+        json={'client_ip': '5.5.5.5', 'auth_result': 'success'},
+        headers={'X-Chain-Password': chain},
+    )
+    assert resp.status_code == 200
+
+    other = TestClient(app)
+    new_chain = other.get('/api/security/chain', headers=_auth_headers(other)).json()['chain']
+    assert new_chain != chain
+    resp = other.post(
+        '/score',
+        json={'client_ip': '5.5.5.5', 'auth_result': 'success'},
+        headers={'X-Chain-Password': chain},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- persist security toggle and chain token in a new `security_state` table
- refactor chain helpers and `/score` endpoint to use DB-backed state
- expand security tests to ensure state persists across clients/workers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68911b162f60832eb9c8ddc58dac06e8