### PR TITLE
Default anomaly model to LOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ anomaly detection, and enforcing a zero‑trust API key:
 - `DEMO_SHOP_URL` – base URL for Demo Shop when forwarding registrations (default `http://localhost:3005`).
 - `ANOMALY_DETECTION` – set to `true` to enable ML-based request anomaly checks (default `false`).
 - `ANOMALY_MODEL` – algorithm used when anomaly detection is enabled. Choose
-  `isolation_forest` or `lof` (default `isolation_forest`).
+  `isolation_forest` or `lof` (default `lof`).
 - `REAUTH_PER_REQUEST` – set to `true` to require the user's password on every API call (default `false`).
 - `ZERO_TRUST_API_KEY` – if set, every request must include this value in the
   `X-API-Key` header. Invalid keys are logged via `/score` and show up in
@@ -86,7 +86,7 @@ LOGIN_WITH_DEMOSHOP=true
 DEMO_SHOP_URL=http://localhost:3005
 ANOMALY_DETECTION=true
 # Algorithm for anomaly detection
-ANOMALY_MODEL=isolation_forest
+ANOMALY_MODEL=lof
 # Require password on every API request
 REAUTH_PER_REQUEST=false
 ZERO_TRUST_API_KEY=demo-key

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,5 +9,7 @@ REGISTER_WITH_DEMOSHOP=true
 LOGIN_WITH_DEMOSHOP=true
 DEMO_SHOP_URL=http://localhost:3005
 ANOMALY_DETECTION=true
+# Algorithm for anomaly detection
+ANOMALY_MODEL=lof
 REAUTH_PER_REQUEST=false
 ZERO_TRUST_API_KEY=demo-key

--- a/backend/app/core/anomaly.py
+++ b/backend/app/core/anomaly.py
@@ -39,7 +39,7 @@ _model: Any = None
 def get_model() -> _Model | None:
     global _model
     if _model is None and IsolationForest is not None:
-        algo = os.getenv("ANOMALY_MODEL", "isolation_forest").lower()
+        algo = os.getenv("ANOMALY_MODEL", "lof").lower()
         _model = _Model(algo)
     return _model
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
     LOGIN_WITH_DEMOSHOP: bool = False
     DEMO_SHOP_URL: str = "http://localhost:3005"
     ANOMALY_DETECTION: bool = False
-    ANOMALY_MODEL: str = "isolation_forest"
+    ANOMALY_MODEL: str = "lof"
     REAUTH_PER_REQUEST: bool = False
     ZERO_TRUST_API_KEY: str = "demo-key"
 

--- a/backend/tests/test_anomaly.py
+++ b/backend/tests/test_anomaly.py
@@ -24,7 +24,7 @@ def teardown_function(_):
     SessionLocal().close()
 
 
-def test_anomalous_path_blocked_iforest(monkeypatch):
+def test_anomalous_path_blocked_lof(monkeypatch):
     monkeypatch.setenv('ANOMALY_DETECTION', 'true')
     monkeypatch.delenv('ANOMALY_MODEL', raising=False)
     client = _reload_app()
@@ -37,9 +37,9 @@ def test_anomalous_path_blocked_iforest(monkeypatch):
     _reload_app()
 
 
-def test_anomalous_path_blocked_lof(monkeypatch):
+def test_anomalous_path_blocked_iforest(monkeypatch):
     monkeypatch.setenv('ANOMALY_DETECTION', 'true')
-    monkeypatch.setenv('ANOMALY_MODEL', 'lof')
+    monkeypatch.setenv('ANOMALY_MODEL', 'isolation_forest')
     client = _reload_app()
 
     path = '/a' + 'b' * 100


### PR DESCRIPTION
## Summary
- set Local Outlier Factor as default `ANOMALY_MODEL`
- document LOF default in README and example env
- adjust anomaly tests for new default

## Testing
- `cd backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68911b09fd54832eac8988ee32d4e2e9