### PR TITLE
Log Demo Shop registration errors

### DIFF
--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -11,6 +11,7 @@ class UserRead(BaseModel):
     id: int
     username: str
     role: str
+    warning: str | None = None
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- log and report Demo Shop registration failures
- include optional warning in user schema
- test failing Demo Shop registration is logged and exposed to clients

## Testing
- `pytest backend/tests/test_auth.py::test_register_forward_error_reported -q`
- `pytest backend/tests -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_6891289c16f4832e8353581f14555f2a