### PR TITLE
Synchronize demo shop login

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,7 +7,7 @@ DB_ECHO=true
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 REGISTER_WITH_DEMOSHOP=true
 LOGIN_WITH_DEMOSHOP=true
-DEMO_SHOP_URL=http://localhost:8001
+DEMO_SHOP_URL=http://localhost:3005
 ANOMALY_DETECTION=true
 # Algorithm for anomaly detection
 ANOMALY_MODEL=lof

--- a/frontend/.env
+++ b/frontend/.env
@@ -3,3 +3,4 @@
 # If the API runs elsewhere, set REACT_APP_API_BASE to the full URL, e.g.:
 # REACT_APP_API_BASE=https://api.example.com
 # REACT_APP_API_BASE=http://localhost:8001
+REACT_APP_SHOP_URL=http://localhost:3005

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { apiFetch, AUTH_TOKEN_KEY, logAuditEvent } from "./api";
+import { apiFetch, AUTH_TOKEN_KEY, USERNAME_KEY, logAuditEvent } from "./api";
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
@@ -18,6 +18,13 @@ export default function LoginForm({ onLogin }) {
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
       localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
+      localStorage.setItem(USERNAME_KEY, username);
+      await fetch(`${process.env.REACT_APP_SHOP_URL}/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ username, password }),
+      });
       await logAuditEvent("user_login_success", username);
       onLogin(data.access_token);
     } catch (err) {


### PR DESCRIPTION
## Summary
- configure demo shop connection via env vars
- store username and sync login with demo shop from frontend

## Testing
- `pytest`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689168a9de88832e8cf3c1b2a801a12f