### PR TITLE
Persist username in login flow

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { apiFetch, AUTH_TOKEN_KEY, logAuditEvent } from "./api";
+import { apiFetch, AUTH_TOKEN_KEY, USERNAME_KEY, logAuditEvent } from "./api";
 
 export default function LoginForm({ onLogin }) {
   const [username, setUsername] = useState("");
@@ -18,6 +18,7 @@ export default function LoginForm({ onLogin }) {
       if (!resp.ok) throw new Error(await resp.text());
       const data = await resp.json();
       localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
+      localStorage.setItem(USERNAME_KEY, username);
       await logAuditEvent("user_login_success", username);
       onLogin(data.access_token);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Save login username in localStorage for reuse across components
- Import USERNAME_KEY alongside other API constants in LoginForm

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891682805c0832e9ed3a8417b8eb7a1