### PR TITLE
Allow React dev server via CORS

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,12 @@ from app.api.audit import router as audit_router
 
 app = FastAPI(title="APIShield+")
 
-allow_origins = ["http://localhost:8001"]
+# Permit requests from local development frontends
+allow_origins = [
+    "http://localhost:8001",  # existing API client
+    "http://localhost:3000",  # React dev server
+]
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allow_origins,


### PR DESCRIPTION
## Summary
- include React dev server in FastAPI CORS allow list

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6891689e1d44832e843290b933d2a392