### PR TITLE
Fix Demo Shop port mismatch

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -37,7 +37,7 @@ def register(user_in: UserCreate, db: Session = Depends(get_db)):
 
     warning: str | None = None
     if os.getenv("REGISTER_WITH_DEMOSHOP", "false").lower() in {"1", "true", "yes"}:
-        shop_url = os.getenv("DEMO_SHOP_URL", "http://localhost:8001").rstrip("/")
+        shop_url = os.getenv("DEMO_SHOP_URL", "http://localhost:3005").rstrip("/")
         try:
             requests.post(
                 f"{shop_url}/register",
@@ -99,7 +99,7 @@ def login(user_in: UserCreate, request: Request, db: Session = Depends(get_db)):
     )
 
     if os.getenv("LOGIN_WITH_DEMOSHOP", "false").lower() in {"1", "true", "yes"}:
-        shop_url = os.getenv("DEMO_SHOP_URL", "http://localhost:8001").rstrip("/")
+        shop_url = os.getenv("DEMO_SHOP_URL", "http://localhost:3005").rstrip("/")
         try:
             requests.post(
                 f"{shop_url}/login",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     DB_ECHO: bool = False
     REGISTER_WITH_DEMOSHOP: bool = False
     LOGIN_WITH_DEMOSHOP: bool = False
-    DEMO_SHOP_URL: str = "http://localhost:8001"
+    DEMO_SHOP_URL: str = "http://localhost:3005"
     ANOMALY_DETECTION: bool = False
     ANOMALY_MODEL: str = "lof"
     REAUTH_PER_REQUEST: bool = False


### PR DESCRIPTION
## Summary
- align default Demo Shop URL with port-forwarded service on port 3005

## Testing
- `cd backend && pip install -r requirements.txt`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a2014f70832ebdf678e001f56f2f