### PR TITLE
Allow demo shop port in CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ demonstration purposes and no license or ownership is claimed.
        --from-literal=SECRET_KEY=<random-secret> \
        --from-literal=DATABASE_URL=sqlite:///app.db \
        --from-literal=ZERO_TRUST_API_KEY=demo-key \
+       --from-literal=ALLOW_ORIGINS=http://localhost:8001,http://localhost:3000,http://localhost:3005 \
        -n demo
    ```
 
@@ -335,6 +336,10 @@ demonstration purposes and no license or ownership is claimed.
    kubectl port-forward svc/kube-prom-prometheus -n monitoring 9090 or kubectl port-forward svc/kube-prom-kube-prometheus-prometheus -n monitoring 9090
    kubectl port-forward svc/kube-prom-grafana -n monitoring 3001:80
    ```
+
+   Ensure the detector's `ALLOW_ORIGINS` environment variable includes
+   `http://localhost:3005` so the demo-shop UI can reach the API without
+   browser CORS errors.
 
    Verify the API is reachable via HTTPS:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,7 @@
 DATABASE_URL=sqlite:///./app.db
 SECRET_KEY=super-secret-key
+# Comma-separated list of hosts allowed by CORS
+ALLOW_ORIGINS=http://localhost:8001,http://localhost:3000,http://localhost:3005
 # Optional tuning parameters
 FAIL_LIMIT=5
 FAIL_WINDOW_SECONDS=60

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,10 +26,14 @@ from app.api.audit import router as audit_router
 app = FastAPI(title="APIShield+")
 
 # Permit requests from local development frontends
-allow_origins = [
-    "http://localhost:8001",  # existing API client
+default_origins = [
+    "http://localhost:8001",  # API client
     "http://localhost:3000",  # React dev server
+    "http://localhost:3005",  # Demo-shop UI (via port-forward)
 ]
+
+# Optionally override via ALLOW_ORIGINS env var (comma-separated)
+allow_origins = [o for o in os.getenv("ALLOW_ORIGINS", "").split(",") if o] or default_origins
 
 app.add_middleware(
     CORSMiddleware,

--- a/demo-shop/README.md
+++ b/demo-shop/README.md
@@ -31,6 +31,9 @@ set `API_PORT=8001` (or `API_BASE=http://localhost:8001`) in the shop's
 environment so its axios client reaches the correct API host. Without these
 variables audit log forwarding will fail silently.
 
+Ensure the detector's `ALLOW_ORIGINS` environment variable includes
+`http://localhost:3005` so browsers permit API calls from the demo-shop UI.
+
 With the server running you can simply open `http://localhost:3005/` in your
 browser to view the demo shop UI. The static files are served from the
 `shop-ui` directory automatically so no additional web server is required.

--- a/infra/k8s/detector-deployment.yaml
+++ b/infra/k8s/detector-deployment.yaml
@@ -33,6 +33,11 @@ spec:
             secretKeyRef:
               name: detector-env
               key: ZERO_TRUST_API_KEY
+        - name: ALLOW_ORIGINS
+          valueFrom:
+            secretKeyRef:
+              name: detector-env
+              key: ALLOW_ORIGINS
         args:
           - uvicorn
           - app.main:app


### PR DESCRIPTION
## Summary
- make CORS origins configurable via `ALLOW_ORIGINS` env var and include demo shop port
- document `ALLOW_ORIGINS` in example env file, k8s deployment, and docs

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891b09a7004832e91b7c74be0c3dc90