### PR TITLE
fix: logouts reset state without reload

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,9 +31,7 @@ function App() {
     const username = localStorage.getItem(USERNAME_KEY);
     await logAuditEvent("user_logout", username);
     localStorage.removeItem(AUTH_TOKEN_KEY);
-    if (username) {
-      localStorage.removeItem(USERNAME_KEY);
-    }
+    localStorage.removeItem(USERNAME_KEY);
     setToken(null);
   };
 


### PR DESCRIPTION
## Summary
- ensure logout clears auth and username keys and updates local token state
- hook Logout button into the internal handler

## Testing
- `cd frontend && CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6891b133a184832eb5d7557cf1581b9e