### PR TITLE
refactor: remove redundant auth headers

### DIFF
--- a/frontend/src/AlertsChart.jsx
+++ b/frontend/src/AlertsChart.jsx
@@ -22,15 +22,13 @@ ChartJS.register(
   Legend
 );
 
-export default function AlertsChart({ token }) {
+export default function AlertsChart() {
   const [stats, setStats] = useState([]);
   const [error, setError] = useState(null);
 
   const loadStats = async () => {
     try {
-      const resp = await apiFetch("/api/alerts/stats", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const resp = await apiFetch("/api/alerts/stats");
       if (!resp.ok) throw new Error(await resp.text());
       setStats(await resp.json());
     } catch (err) {

--- a/frontend/src/AlertsTable.jsx
+++ b/frontend/src/AlertsTable.jsx
@@ -1,15 +1,13 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function AlertsTable({ refresh, token }) {
+export default function AlertsTable({ refresh }) {
   const [alerts, setAlerts] = useState([]);
   const [error, setError] = useState(null);
 
   const loadAlerts = async () => {
     try {
-      // Only include Authorization header when a token is available
-      const headers = token ? { Authorization: `Bearer ${token}` } : {};
-      const resp = await apiFetch("/api/alerts", { headers });
+      const resp = await apiFetch("/api/alerts");
       if (!resp.ok) throw new Error(await resp.text());
       setAlerts(await resp.json());
     } catch (err) {

--- a/frontend/src/EventsTable.jsx
+++ b/frontend/src/EventsTable.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function EventsTable({ token }) {
+export default function EventsTable() {
   const [events, setEvents] = useState([]);
   const [error, setError] = useState(null);
   const [hours, setHours] = useState(24);
@@ -9,9 +9,7 @@ export default function EventsTable({ token }) {
   const load = async () => {
     const query = hours ? `?hours=${hours}` : "";
     try {
-      const resp = await apiFetch(`/api/events${query}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const resp = await apiFetch(`/api/events${query}`);
       if (!resp.ok) throw new Error(await resp.text());
       setEvents(await resp.json());
     } catch (err) {

--- a/frontend/src/LoginStatus.jsx
+++ b/frontend/src/LoginStatus.jsx
@@ -7,9 +7,7 @@ export default function LoginStatus({ token }) {
 
   const load = async () => {
     try {
-      const resp = await apiFetch("/api/last-logins", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const resp = await apiFetch("/api/last-logins");
       if (!resp.ok) throw new Error(await resp.text());
       setLogins(await resp.json());
     } catch (err) {


### PR DESCRIPTION
## Summary
- rely on apiFetch's automatic JWT handling instead of manual Authorization headers
- simplify alerts and events components

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891b25716d0832e91eaaa665f6929c9