### PR TITLE
Refine dashboard components and add policy API

### DIFF
--- a/backend/app/api/policies.py
+++ b/backend/app/api/policies.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.db import get_db
+from app.api.dependencies import require_role
+from app.crud.policies import create_policy, get_policy_by_id
+from app.crud.users import get_user_by_username
+from app.schemas.policies import PolicyCreate, PolicyRead
+
+router = APIRouter(prefix="/api", tags=["policies"])
+
+
+@router.post("/policies", response_model=PolicyRead)
+def create_policy_endpoint(
+    policy: PolicyCreate,
+    _user=Depends(require_role("admin")),
+    db: Session = Depends(get_db),
+):
+    return create_policy(
+        db,
+        failed_attempts_limit=policy.failed_attempts_limit,
+        mfa_required=policy.mfa_required,
+        geo_fencing_enabled=policy.geo_fencing_enabled,
+    )
+
+
+@router.post("/users/{username}/policy/{policy_id}")
+def assign_policy(
+    username: str,
+    policy_id: int,
+    _user=Depends(require_role("admin")),
+    db: Session = Depends(get_db),
+):
+    user = get_user_by_username(db, username)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    policy = get_policy_by_id(db, policy_id)
+    if not policy:
+        raise HTTPException(status_code=404, detail="Policy not found")
+    user.policy_id = policy_id
+    db.commit()
+    return {"username": user.username, "policy_id": policy_id}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.api.events import router as events_router
 from app.api.last_logins import router as last_logins_router
 from app.api.access_logs import router as access_logs_router
 from app.api.audit import router as audit_router
+from app.api.policies import router as policies_router
 
 app = FastAPI(title="APIShield+")
 
@@ -29,6 +30,7 @@ app = FastAPI(title="APIShield+")
 allow_origins = [
     "http://localhost:8001",  # existing API client
     "http://localhost:3000",  # React dev server
+    "http://localhost:3005",  # demo shop
 ]
 
 app.add_middleware(
@@ -68,6 +70,7 @@ app.include_router(events_router)   # /api/events
 app.include_router(last_logins_router)  # /api/last-logins
 app.include_router(access_logs_router)  # /api/access-logs
 app.include_router(audit_router)  # /api/audit/log
+app.include_router(policies_router)  # /api/policies and assignments
 
 
 @app.get("/ping")

--- a/backend/app/schemas/policies.py
+++ b/backend/app/schemas/policies.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class PolicyCreate(BaseModel):
+    failed_attempts_limit: int
+    mfa_required: bool = False
+    geo_fencing_enabled: bool = False
+
+
+class PolicyRead(PolicyCreate):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/demo-shop/.env
+++ b/demo-shop/.env
@@ -1,0 +1,4 @@
+FORWARD_API=true
+API_BASE=http://localhost:8001
+# Optional: API_PORT=8001
+API_KEY=changeme

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -164,7 +164,7 @@ export default function AttackSim({ user, token }) {
           firstTime = (performance.now() - start) / 1000;
           if (token) {
             try {
-              const infoResp = await apiFetch("/api/me", {
+              const infoResp = await fetch(`${API_BASE}/api/me`, {
                 headers: { Authorization: `Bearer ${token}` },
               });
               if (infoResp.ok) {

--- a/frontend/src/UserAccounts.jsx
+++ b/frontend/src/UserAccounts.jsx
@@ -37,7 +37,7 @@ export default function UserAccounts({ onSelect }) {
 
   return (
     <div className="user-accounts">
-      <div className="user-buttons">
+      <div className="user-selector">
         {Object.keys(USER_DATA).map((u) => (
           <button
             key={u}
@@ -50,10 +50,6 @@ export default function UserAccounts({ onSelect }) {
       </div>
       <div className="user-info">
         <h3>{info.name} Security</h3>
-        <div className="progress">
-          <div style={{ width: `${info.security}%` }} />
-        </div>
-
         <p>{info.security}% safe</p>
         <ul>
           {info.features.map((f) => (


### PR DESCRIPTION
## Summary
- fix incomplete UserAccounts markup
- remove duplicate Authorization header in AttackSim
- expose policy creation/assignment endpoints and include demo shop in CORS

## Testing
- `pytest`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6891b396046c832e90be41dd204611f0