### PR TITLE
refactor: internalize logout helper

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -27,6 +27,7 @@ function App() {
     return () => clearInterval(id);
   }, []);
 
+  // Clear session tokens and log the event without a full reload
   const handleLogout = async () => {
     const username = localStorage.getItem(USERNAME_KEY);
     await logAuditEvent("user_logout", username);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -20,7 +20,7 @@ export async function logAuditEvent(event, username) {
   }
 }
 
-export function logout() {
+function logout() {
   const username = localStorage.getItem(USERNAME_KEY);
   if (localStorage.getItem(AUTH_TOKEN_KEY)) {
     logAuditEvent("user_logout", username);


### PR DESCRIPTION
## Summary
- keep the dashboard's logout button wired to a local `handleLogout`
- hide the API helper's `logout` function from external imports

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891b825a558832e8831d6dc89bb4c18