### PR TITLE
Allow configuring CORS origins and document demo shop port

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ demonstration purposes and no license or ownership is claimed.
        --from-literal=ALLOW_ORIGINS=http://localhost:8001,http://localhost:3000,http://localhost:3005 \
        -n demo
    ```
+   Ensure `ALLOW_ORIGINS` includes the demo-shop port (`http://localhost:3005`) so the UI can reach the API.
 
    Replace `<random-secret>` with any string you want to use as the secret key.
 4. Build the detector image:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,6 @@
 DATABASE_URL=sqlite:///./app.db
 SECRET_KEY=super-secret-key
-# Comma-separated list of hosts allowed by CORS
+# Comma-separated list of hosts allowed by CORS (include demo-shop port)
 ALLOW_ORIGINS=http://localhost:8001,http://localhost:3000,http://localhost:3005
 # Optional tuning parameters
 FAIL_LIMIT=5

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,13 +28,13 @@ app = FastAPI(title="APIShield+")
 
 # Permit requests from local development frontends
 default_origins = [
-    "http://localhost:8001",  # API client
-    "http://localhost:3000",  # React dev server
-    "http://localhost:3005",  # Demo-shop UI (via port-forward)
+    "http://localhost:8001",
+    "http://localhost:3000",
+    "http://localhost:3005",
 ]
 
 # Optionally override via ALLOW_ORIGINS env var (comma-separated)
-allow_origins = [o for o in os.getenv("ALLOW_ORIGINS", "").split(",") if o] or default_origins
+allow_origins = os.getenv("ALLOW_ORIGINS", "").split(",") or default_origins
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- allow overriding CORS origins via `ALLOW_ORIGINS`
- document that the Demo-Shop port must be listed in `ALLOW_ORIGINS`

## Testing
- `flake8 backend/app/main.py`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_6891bb6ba3a4832eb00925bd4b6866dc