### PR TITLE
docs: note apiFetch handles auth

### DIFF
--- a/frontend/src/AlertsChart.jsx
+++ b/frontend/src/AlertsChart.jsx
@@ -28,6 +28,7 @@ export default function AlertsChart() {
 
   const loadStats = async () => {
     try {
+      // apiFetch automatically appends authentication headers
       const resp = await apiFetch("/api/alerts/stats");
       if (!resp.ok) throw new Error(await resp.text());
       setStats(await resp.json());

--- a/frontend/src/AlertsTable.jsx
+++ b/frontend/src/AlertsTable.jsx
@@ -7,6 +7,7 @@ export default function AlertsTable({ refresh }) {
 
   const loadAlerts = async () => {
     try {
+      // apiFetch automatically appends authentication headers
       const resp = await apiFetch("/api/alerts");
       if (!resp.ok) throw new Error(await resp.text());
       setAlerts(await resp.json());

--- a/frontend/src/EventsTable.jsx
+++ b/frontend/src/EventsTable.jsx
@@ -9,6 +9,7 @@ export default function EventsTable() {
   const load = async () => {
     const query = hours ? `?hours=${hours}` : "";
     try {
+      // apiFetch automatically appends authentication headers
       const resp = await apiFetch(`/api/events${query}`);
       if (!resp.ok) throw new Error(await resp.text());
       setEvents(await resp.json());

--- a/frontend/src/LoginStatus.jsx
+++ b/frontend/src/LoginStatus.jsx
@@ -7,6 +7,7 @@ export default function LoginStatus({ token }) {
 
   const load = async () => {
     try {
+      // apiFetch automatically appends authentication headers
       const resp = await apiFetch("/api/last-logins");
       if (!resp.ok) throw new Error(await resp.text());
       setLogins(await resp.json());


### PR DESCRIPTION
## Summary
- note in login, alerts, and events components that `apiFetch` automatically attaches auth headers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891bbf2fcac832e9f105328294502ef