### PR TITLE
Use loopback IP for demo shop API

### DIFF
--- a/demo-shop/.env
+++ b/demo-shop/.env
@@ -1,4 +1,3 @@
+API_BASE=http://127.0.0.1:8001
 FORWARD_API=true
-API_BASE=http://localhost:8001
-# Optional: API_PORT=8001
-API_KEY=changeme
+API_KEY=<your ZERO_TRUST_API_KEY>

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -7,8 +7,8 @@ const { spawn } = require('child_process');
 
 const app = express();
 const PORT = process.env.PORT || 3005;
-// Build the API base URL from API_BASE or API_PORT. Defaults to localhost:8001.
-const API_BASE = process.env.API_BASE || `http://localhost:${process.env.API_PORT || 8001}`;
+// Build the API base URL from API_BASE. Defaults to 127.0.0.1:8001.
+const API_BASE = process.env.API_BASE || 'http://127.0.0.1:8001';
 const API_TIMEOUT = parseInt(process.env.API_TIMEOUT_MS || '2000', 10);
 // Forward shop events to the APIShield backend unless explicitly disabled.
 // Disable backend integration entirely by setting FORWARD_API=false.


### PR DESCRIPTION
## Summary
- default demo shop API endpoint to 127.0.0.1 instead of localhost
- configure demo shop .env with API forwarding and API key placeholders

## Testing
- `npm test` (fails: Missing script)
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_6891c90f564c832e9e7a20495c0845ba