### PR TITLE
docs: document API base for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,13 @@ The next request starts with a clean slate.
 ```bash
 cd frontend
 npm install
-npm start
+REACT_APP_API_BASE=http://127.0.0.1:8001 npm start
 ```
 
-The dashboard uses the `REACT_APP_API_BASE` environment variable to reach the backend API. By default, requests are proxied to `http://localhost:8001`. If your API runs on a different host or port, set `REACT_APP_API_BASE` in `frontend/.env` or when starting the app (e.g., `REACT_APP_API_BASE=https://api.example.com npm start`). Set `REACT_APP_API_KEY` if the backend requires an `X-API-Key` header.
+The dashboard reads the `REACT_APP_API_BASE` environment variable to locate the
+backend API. Setting it as shown above causes `apiFetch('/login')` to expand to
+`http://127.0.0.1:8001/login`. You may also place this value in `frontend/.env`.
+Set `REACT_APP_API_KEY` if the backend requires an `X-API-Key` header.
 
 The React application will be available at [http://localhost:3000](http://localhost:3000).
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,6 +1,6 @@
-# Base URL for the backend API.
-# Leave unset to allow Create React App's proxy to reach http://localhost:8001.
-# If the API runs elsewhere, set REACT_APP_API_BASE to the full URL, e.g.:
-# REACT_APP_API_BASE=https://api.example.com
-# REACT_APP_API_BASE=http://localhost:8001
+# Base URL for the backend API. Set this so apiFetch('/login') resolves to
+# the correct server. The development backend listens on 127.0.0.1:8001.
+REACT_APP_API_BASE=http://127.0.0.1:8001
+
+# URL for the demo shop used by the dashboard.
 REACT_APP_SHOP_URL=http://localhost:3005

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,13 +6,16 @@ Refer to the root README for instructions on starting the shop.
 
 ## Environment Variables
 
-The dashboard uses the `REACT_APP_API_BASE` environment variable to reach
-the backend API. It defaults to an empty string so Create React App's proxy
-can forward requests to the backend at `http://localhost:8001`.
+The dashboard uses the `REACT_APP_API_BASE` environment variable to reach the
+backend API. Set it before starting the dev server so calls such as
+`apiFetch('/login')` expand to the full URL. For local development the backend
+listens on `http://127.0.0.1:8001`:
 
-If your API runs on a different host or port, set `REACT_APP_API_BASE` in
-`frontend/.env` or provide it through your start script so the dashboard can
-locate the correct endpoint.
+```bash
+REACT_APP_API_BASE=http://127.0.0.1:8001 npm start
+```
+
+You may instead place the same value in `frontend/.env`.
 
 ## Available Scripts
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,4 @@
-// Base URL for the backend API. If unset, requests use relative paths and rely on CRA's proxy.
+// Base URL for the backend API. Reads REACT_APP_API_BASE (e.g., http://127.0.0.1:8001).
 export const API_BASE = process.env.REACT_APP_API_BASE || "";
 export const API_KEY = process.env.REACT_APP_API_KEY || "";
 export const AUTH_TOKEN_KEY = "apiShieldAuthToken";


### PR DESCRIPTION
## Summary
- clarify that the dashboard should be started with `REACT_APP_API_BASE=http://127.0.0.1:8001`
- document example `npm start` command and default `.env` value
- note that `apiFetch('/login')` will hit the full backend URL

## Testing
- `npm test -- --watchAll=false` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6891c929b46c832eab75a3d17aef7dec