### PR TITLE
Allow localhost origins for CORS

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,9 @@ default_origins = [
     "http://127.0.0.1:8001",  # API itself
     "http://127.0.0.1:3000",  # React dashboard
     "http://127.0.0.1:3005",  # Demo-shop UI
+    "http://localhost:8001",  # API itself (localhost)
+    "http://localhost:3000",  # React dashboard (localhost)
+    "http://localhost:3005",  # Demo-shop UI (localhost)
 ]
 
 # Optionally override via ALLOW_ORIGINS env var (comma-separated)


### PR DESCRIPTION
## Summary
- permit localhost addresses in default CORS origins

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891ccd545b0832eac50d9b2b9a041e5