### PR TITLE
Add bootstrap-based security progress bars

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "bootstrap": "^5.3.7",
         "chart.js": "^4.4.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.2.0",
@@ -2893,6 +2894,17 @@
         }
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -4904,6 +4916,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "bootstrap": "^5.3.7",
     "chart.js": "^4.4.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.2.0",
@@ -38,6 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {}
+  }
 }

--- a/frontend/src/UserAccounts.jsx
+++ b/frontend/src/UserAccounts.jsx
@@ -5,7 +5,7 @@ export const USER_DATA = {
     name: "Alice",
     password: "secret",
 
-    security: 30,
+    security: 25,
     features: [
       "Weak password",
       "No MFA",
@@ -37,23 +37,39 @@ export default function UserAccounts({ onSelect }) {
 
   return (
     <div className="user-accounts">
-      <div className="user-selector">
+      <div className="btn-group mb-3">
         {Object.keys(USER_DATA).map((username) => (
           <button
             key={username}
+            type="button"
             onClick={() => handleSelect(username)}
-            className={active === username ? "active" : ""}
+            className={`btn btn-${active === username ? "primary" : "outline-primary"}`}
           >
             {USER_DATA[username].name}
           </button>
         ))}
       </div>
-      <div className="user-info">
-        <h3>{selected.name} Security</h3>
-        <p>{selected.security}% safe</p>
-        <ul>
+      <div className="card">
+        <div className="card-body">
+          <h3 className="card-title">{selected.name} Security</h3>
+          <div className="progress mb-3">
+            <div
+              className="progress-bar"
+              role="progressbar"
+              style={{ width: `${selected.security}%` }}
+              aria-valuenow={selected.security}
+              aria-valuemin="0"
+              aria-valuemax="100"
+            >
+              {selected.security}%
+            </div>
+          </div>
+        </div>
+        <ul className="list-group list-group-flush">
           {selected.features.map((feature) => (
-            <li key={feature}>{feature}</li>
+            <li key={feature} className="list-group-item">
+              {feature}
+            </li>
           ))}
         </ul>
       </div>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';


### PR DESCRIPTION
## Summary
- style user account display with Bootstrap including progress bars
- add Bootstrap CSS import and dependency

## Testing
- `CI=true npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6891d0a55fe8832eaff71cd8c9eb454c