### PR TITLE
Limit stored events to major actions

### DIFF
--- a/backend/app/api/score.py
+++ b/backend/app/api/score.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from app.core.db import get_db
 from app.models.alerts import Alert
 import app.api.security as security
+from app.core.events import log_event
 
 router = APIRouter(
     prefix="",            # no /api prefix for /score
@@ -106,8 +107,13 @@ def record_attempt(
             attempts = attempts[-fail_limit:]
         FAILED_USER_ATTEMPTS[user_id] = attempts
 
+    # Record the failed attempt for the event log.  The username is unknown at
+    # this stage so ``None`` is stored.
+    log_event(db, None, "stuffing_attempt", False)
+
     if security.is_enabled(db) and fail_count >= ip_fail_limit:
         STUFFING_DETECTIONS.labels(ip=client_ip).inc()
+        log_event(db, None, "stuffing_block", True)
         alert = Alert(
             ip_address=client_ip,
             total_fails=fail_count + 1,

--- a/backend/app/core/events.py
+++ b/backend/app/core/events.py
@@ -1,6 +1,27 @@
+"""Utility for recording notable actions in the event log.
+
+Only a small subset of actions are considered "major" and therefore stored in
+the database.  This helps keep the dashboard focused by ignoring the many
+minor interactions that previously produced excessive rows.
+"""
+
 from sqlalchemy.orm import Session
+
 from app.crud.events import create_event
+
+# Actions that should result in a persisted event. Anything else passed to
+# ``log_event`` will be quietly ignored.
+MAJOR_EVENTS = {
+    "login",
+    "logout",
+    "stuffing_attempt",
+    "shop_login_error",
+    "stuffing_block",
+}
 
 
 def log_event(db: Session, username: str | None, action: str, success: bool) -> None:
+    """Persist an event if it is considered major."""
+    if action not in MAJOR_EVENTS:
+        return
     create_event(db, username, action, success)


### PR DESCRIPTION
## Summary
- Persist only major dashboard events like logins, logouts, credential stuffing attempts/blocks, and Demo Shop login failures
- Record credential stuffing attempts and blocks in the score API

## Testing
- `cd backend && pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6891e15e7cc8832eab2feca2fa5d4bde