### PR TITLE
fix: align demo-shop auth payload with backend schema

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -69,7 +69,10 @@ function requireAuth(req, res, next) {
 }
 
 app.post('/register', async (req, res) => {
-  const { username, password } = req.body;
+  // Accept both the legacy `user`/`pass` fields and the
+  // newer `username`/`password` pair used by the backend.
+  const username = req.body.username || req.body.user;
+  const password = req.body.password || req.body.pass;
   if (!username || !password) return res.status(400).json({ error: 'missing' });
   if (users[username]) return res.status(409).json({ error: 'exists' });
   users[username] = { password, cart: [] };
@@ -89,7 +92,9 @@ app.post('/register', async (req, res) => {
 });
 
 app.post('/login', async (req, res) => {
-  const { username, password } = req.body;
+  // Handle both `username`/`password` and legacy `user`/`pass` fields.
+  const username = req.body.username || req.body.user;
+  const password = req.body.password || req.body.pass;
   if (!users[username] || users[username].password !== password) {
     if (FORWARD_API) {
       await api


### PR DESCRIPTION
## Summary
- ensure demo shop forwards `username` and `password` when interacting with backend
- accept legacy `user`/`pass` fields and translate them for APIShield backend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689305c6cdcc832ea63ad84af3e7749d