### PR TITLE
Require username for audit log entries

### DIFF
--- a/backend/app/crud/audit.py
+++ b/backend/app/crud/audit.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Session
 from app.models.audit_logs import AuditLog
 
 
-def create_audit_log(db: Session, username: str | None, event: str) -> AuditLog:
+def create_audit_log(db: Session, username: str, event: str) -> AuditLog:
     log = AuditLog(username=username, event=event)
     db.add(log)
     db.commit()

--- a/backend/app/models/audit_logs.py
+++ b/backend/app/models/audit_logs.py
@@ -7,6 +7,6 @@ class AuditLog(Base):
     __tablename__ = "audit_logs"
 
     id = Column(Integer, primary_key=True, index=True)
-    username = Column(String, nullable=True, index=True)
+    username = Column(String, nullable=False, index=True)
     event = Column(String, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional
 from pydantic import BaseModel
 
 
@@ -15,7 +14,7 @@ class AuditEventType(str, Enum):
 
 class AuditLogCreate(BaseModel):
     event: AuditEventType
-    username: Optional[str] = None
+    username: str
 
 
 class AuditLogRead(AuditLogCreate):

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -31,3 +31,8 @@ def test_audit_log_persists_event():
 def test_audit_log_rejects_invalid_event():
     resp = client.post('/api/audit/log', json={'event': 'invalid_event', 'username': 'alice'})
     assert resp.status_code == 422
+
+
+def test_audit_log_missing_username():
+    resp = client.post('/api/audit/log', json={'event': 'user_login_success'})
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- ensure audit log payload includes username and store it non-null
- add regression test for missing username

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689324f4ba68832e93954307b80418a9