### PR TITLE
feat: reflect zero trust status on dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,6 +18,7 @@ function App() {
   const [policy, setPolicy] = useState(null);
   const [attackStatus, setAttackStatus] = useState(null);
   const [cartData, setCartData] = useState(null);
+  const [zeroTrustEnabled, setZeroTrustEnabled] = useState(true);
 
 
   // Poll for token changes across tabs/apps
@@ -39,11 +40,18 @@ function App() {
     setPolicy(null);
     setAttackStatus(null);
     setCartData(null);
+    setZeroTrustEnabled(true);
   };
 
-  // Refresh tables when auth status changes
+  // Refresh tables and set zero-trust flag when auth status changes
   useEffect(() => {
     setRefreshKey((k) => k + 1);
+    const username = localStorage.getItem(USERNAME_KEY);
+    if (username === "alice") {
+      setZeroTrustEnabled(false);
+    } else {
+      setZeroTrustEnabled(true);
+    }
   }, [token]);
 
   if (!token) {
@@ -51,7 +59,18 @@ function App() {
       <div className="app-container">
         <h1 className="dashboard-header">Please log in</h1>
         <div className="dashboard-section">
-          <LoginForm onLogin={(tok, pol) => { setToken(tok); setPolicy(pol); }} />
+          <LoginForm
+            onLogin={(tok, pol) => {
+              setToken(tok);
+              setPolicy(pol);
+              const username = localStorage.getItem(USERNAME_KEY);
+              if (username === "alice") {
+                setZeroTrustEnabled(false);
+              } else {
+                setZeroTrustEnabled(true);
+              }
+            }}
+          />
         </div>
       </div>
     );
@@ -116,7 +135,7 @@ function App() {
             <button onClick={runStuffing}>Attack Demo Shop (Ben)</button>
           )}
           <div className="security-box">
-            <SecurityToggle />
+            <SecurityToggle forcedState={zeroTrustEnabled} />
           </div>
         </div>
         {attackStatus && <p>{attackStatus}</p>}

--- a/frontend/src/SecurityToggle.jsx
+++ b/frontend/src/SecurityToggle.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { apiFetch, ZERO_TRUST_ENABLED_KEY } from "./api";
 
-export default function SecurityToggle() {
-  const [enabled, setEnabled] = useState(true);
+export default function SecurityToggle({ forcedState = null }) {
+  const [enabled, setEnabled] = useState(forcedState ?? true);
   const [error, setError] = useState(null);
 
   const loadState = async () => {
@@ -24,8 +24,16 @@ export default function SecurityToggle() {
   };
 
   useEffect(() => {
-    loadState();
-  }, []);
+    if (forcedState === null) {
+      loadState();
+    } else {
+      setEnabled(forcedState);
+      localStorage.setItem(
+        ZERO_TRUST_ENABLED_KEY,
+        forcedState ? "true" : "false"
+      );
+    }
+  }, [forcedState]);
 
   const toggle = async () => {
     try {


### PR DESCRIPTION
## Summary
- track zero-trust enabled state based on logged in user
- allow SecurityToggle to accept forced state override

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689329ff06f0832e8ec7aa4039b29e6b