### PR TITLE
Add demo shop credential stuffing simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ server starts your default browser opens the shop home page automatically at
    `POST /api/users/{username}/policy/{policy_id}`. This setup shows how
    different policy settings affect the outcome of the demo.
 
+   To generate traffic against the demo shop directly, the API exposes
+   `POST /simulate/demo-shop-attack`. This endpoint tries a small list of common
+   passwords against the shop's `/login` route and returns the HTTP status for
+   each attempt. The dashboard provides a **Run Credential Stuffing on Demo-Shop**
+   button which sends `{ "attempts": 50 }` to this route and displays the
+   results.
+
 
 2. Log in and locate the **Credential Stuffing Simulation** section. Choose a
    target account and click **Start Attack**. When targeting Alice the attack

--- a/backend/app/api/demo_shop_sim.py
+++ b/backend/app/api/demo_shop_sim.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+import requests, os
+
+router = APIRouter()
+
+COMMON_PWS = ["secret", "password", "123456", "ilikepizza"]
+
+@router.post("/simulate/demo-shop-attack")
+def attack(payload: dict):
+    attempts = payload.get("attempts", 50)
+    shop_url = os.getenv("DEMO_SHOP_URL", "http://localhost:3005")
+    results = []
+    for _ in range(attempts):
+        for pw in COMMON_PWS:
+            r = requests.post(f"{shop_url}/login", json={"username":"alice","password":pw})
+            results.append({"password": pw, "status": r.status_code})
+    return {"results": results}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from app.api.last_logins import router as last_logins_router
 from app.api.access_logs import router as access_logs_router
 from app.api.audit import router as audit_router
 from app.api.policies import router as policies_router
+from app.api.demo_shop_sim import router as demo_shop_sim_router
 
 app = FastAPI(title="APIShield+")
 
@@ -81,6 +82,7 @@ app.include_router(last_logins_router)  # /api/last-logins
 app.include_router(access_logs_router)  # /api/access-logs
 app.include_router(audit_router)  # /api/audit/log
 app.include_router(policies_router)  # /api/policies and assignments
+app.include_router(demo_shop_sim_router)
 
 
 @app.get("/ping")

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -79,6 +79,7 @@ export default function AttackSim({ user, token }) {
   const [results, setResults] = useState(null);
   const [error, setError] = useState(null);
   const [chainToken, setChainToken] = useState(null);
+  const [demoResults, setDemoResults] = useState(null);
   const chainRef = useRef(null);
 
   const fetchChainToken = async () => {
@@ -244,6 +245,22 @@ export default function AttackSim({ user, token }) {
     setRunning(false);
   };
 
+  const runDemoShopAttack = async () => {
+    try {
+      const resp = await apiFetch("/simulate/demo-shop-attack", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ attempts: 50 }),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        setDemoResults(data.results);
+      }
+    } catch (err) {
+      // ignore errors
+    }
+  };
+
   return (
     <div className="attack-sim">
       <h2>Credential Stuffing Simulation</h2>
@@ -302,6 +319,16 @@ export default function AttackSim({ user, token }) {
       )}
       <div className="attack-alerts">
         <AlertsChart token={token} />
+      </div>
+      <div style={{ marginTop: "1rem" }}>
+        <button onClick={runDemoShopAttack}>
+          Run Credential Stuffing on Demo-Shop
+        </button>
+        {demoResults && (
+          <pre>
+            <code>{JSON.stringify(demoResults, null, 2)}</code>
+          </pre>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add new `/simulate/demo-shop-attack` endpoint to brute force demo shop with common passwords
- expose the endpoint in FastAPI and dashboard
- document the simulation in README

## Testing
- `cd backend && pytest`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68932ef2cd9c832e87a6a14bcc649a9d