### PR TITLE
Ensure cart requests send auth session cookie

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -13,7 +13,7 @@ function setContent(html, callback) {
 
 async function fetchJSON(url, options = {}) {
   const { noAuth, ...opts } = options;
-  const fetchOpts = { headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', ...opts };
+  const fetchOpts = { headers: { 'Content-Type': 'application/json' }, credentials: 'include', ...opts };
   if (!noAuth) {
     const token = localStorage.getItem(AUTH_TOKEN_KEY);
     if (token) {


### PR DESCRIPTION
## Summary
- Send browser credentials on all shop UI `fetchJSON` requests so session cookie goes to `/cart`, `/purchase`, and `/api-calls`.

## Testing
- `npm test` (fails: could not read package.json)
- `npm test` in `demo-shop` (fails: missing script `test`)
- Started demo-shop server and attempted login/cart access; `/cart` responded `Unauthorized` because API token not available

------
https://chatgpt.com/codex/tasks/task_e_68933c2ecff8832ea15e49671e3fd1c4