### PR TITLE
Ensure usernames are always logged in audit events

### DIFF
--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.db import get_db
@@ -37,6 +37,8 @@ async def _broadcast(event: str) -> None:
 @router.post("/log")
 async def audit_log(log: AuditLogCreate, db: Session = Depends(get_db)):
     """Record an audit event from a frontend and broadcast to listeners."""
+    if not log.username or not log.username.strip():
+        raise HTTPException(status_code=422, detail="username is required")
     create_audit_log(db, log.username, log.event.value)
     await _broadcast(log.event.value)
     return {"status": "logged"}

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -14,7 +14,7 @@ class AuditEventType(str, Enum):
 
 class AuditLogCreate(BaseModel):
     event: AuditEventType
-    username: str
+    username: str  # required
 
 
 class AuditLogRead(AuditLogCreate):

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -83,7 +83,10 @@ app.post('/register', async (req, res) => {
       console.error('Register API call failed');
     }
     try {
-      await api.post('/api/audit/log', { event: 'user_register', username });
+      await api.post('/api/audit/log', {
+        event: 'user_register',
+        username: username || 'unknown',
+      });
     } catch (e) {
       console.error('Audit log failed');
     }
@@ -115,7 +118,10 @@ app.post('/login', async (req, res) => {
         console.error('Score API call failed');
       }
       try {
-        await api.post('/api/audit/log', { event: 'user_login_failure', username });
+        await api.post('/api/audit/log', {
+          event: 'user_login_failure',
+          username: username || 'unknown',
+        });
       } catch (e) {
         console.error('Audit log failed');
       }
@@ -141,7 +147,10 @@ app.post('/login', async (req, res) => {
       console.error('Score API call failed');
     }
     try {
-      await api.post('/api/audit/log', { event: 'user_login_success', username });
+      await api.post('/api/audit/log', {
+        event: 'user_login_success',
+        username: username || 'unknown',
+      });
     } catch (e) {
       console.error('Audit log failed');
     }
@@ -163,7 +172,7 @@ app.post('/logout', async (req, res) => {
     try {
       await api.post('/api/audit/log', {
         event: 'user_logout',
-        username: req.session.username,
+        username: req.session.username || 'unknown',
       });
     } catch (e) {
       console.error('Audit log failed', e);


### PR DESCRIPTION
## Summary
- always include a username when demo shop emits audit logs
- require a username for audit logs and validate it's not empty

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934ebeb664832e96b777a891a4f705