### PR TITLE
Add user activity and data exfiltration demos

### DIFF
--- a/backend/app/crud/audit.py
+++ b/backend/app/crud/audit.py
@@ -1,4 +1,7 @@
+from typing import List
+
 from sqlalchemy.orm import Session
+
 from app.models.audit_logs import AuditLog
 
 
@@ -8,3 +11,13 @@ def create_audit_log(db: Session, username: str, event: str) -> AuditLog:
     db.commit()
     db.refresh(log)
     return log
+
+
+def get_all_activity_for_user(db: Session, username: str) -> List[AuditLog]:
+    """Return all audit logs for the specified username."""
+    return (
+        db.query(AuditLog)
+        .filter(AuditLog.username == username)
+        .order_by(AuditLog.timestamp.desc())
+        .all()
+    )

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -230,6 +230,24 @@ app.post('/purchase', requireAuth, (req, res) => {
   res.json({ status: 'purchased' });
 });
 
+app.get('/activity/:username', requireAuth, async (req, res) => {
+  if (!req.session.apiToken) {
+    return res.status(401).json({ error: 'no api token' });
+  }
+  if (!FORWARD_API) {
+    return res.json([]);
+  }
+  try {
+    const resp = await api.get(`/api/audit/activity/${req.params.username}`, {
+      headers: { Authorization: `Bearer ${req.session.apiToken}` },
+    });
+    res.json(resp.data);
+  } catch (e) {
+    console.error('Activity fetch failed');
+    res.status(500).json({ error: 'failed' });
+  }
+});
+
 app.get('/api-calls', requireAuth, async (req, res) => {
   if (!req.session.apiToken) {
     return res.status(401).json({ error: 'no api token' });

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -122,6 +122,7 @@ export default function AttackSim({ user, token }) {
     let firstTime = null;
     let firstInfo = null;
     let cart = null;
+    let activity = null;
 
     const start = performance.now();
 
@@ -202,6 +203,10 @@ export default function AttackSim({ user, token }) {
               if (infoResp.ok) {
                 firstInfo = await infoResp.json();
               }
+              const actResp = await apiFetch(`/api/audit/activity/${targetUser}`);
+              if (actResp.ok) {
+                activity = await actResp.json();
+              }
               if (prevToken) {
                 localStorage.setItem(AUTH_TOKEN_KEY, prevToken);
               } else {
@@ -235,6 +240,7 @@ export default function AttackSim({ user, token }) {
         first_success_time: firstTime,
         first_user_info: firstInfo,
         cart,
+        activity,
       });
 
       await new Promise((res) => setTimeout(res, 100));
@@ -302,15 +308,30 @@ export default function AttackSim({ user, token }) {
                   <code>{JSON.stringify(results.first_user_info)}</code>
                 </p>
               )}
+            </>
+          )}
+          {results.activity && (
+            <div>
+              <h3>Compromised Data</h3>
+              <div>
+                <h4>Audit Log</h4>
+                <ul>
+                  {results.activity.map((a) => (
+                    <li key={a.id}>
+                      {a.event} - {a.timestamp}
+                    </li>
+                  ))}
+                </ul>
+              </div>
               {results.cart && (
                 <div>
-                  <p>Cart</p>
+                  <h4>Cart</h4>
                   <pre>
                     <code>{JSON.stringify(results.cart, null, 2)}</code>
                   </pre>
                 </div>
               )}
-            </>
+            </div>
           )}
           {results.total_time && (
             <p>Total Time: {results.total_time.toFixed(2)}s</p>

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -138,6 +138,18 @@ async function viewStats() {
   }
 }
 
+async function viewActivity() {
+  try {
+    const events = await fetchJSON(`/activity/${username}`);
+    const list = events
+      .map(e => `<li class="list-group-item d-flex justify-content-between"><span>${e.event}</span><span>${new Date(e.timestamp).toLocaleString()}</span></li>`) 
+      .join('');
+    setContent(`<h2>Activity Log</h2><ul class="list-group activity-list">${list}</ul>`);
+  } catch (e) {
+    showMessage('Failed to load activity', true);
+  }
+}
+
 function showLogin() {
   setContent(`
     <h2>Login</h2>
@@ -275,6 +287,7 @@ function init() {
   document.getElementById('loginBtn').addEventListener('click', showLogin);
   document.getElementById('logoutBtn').addEventListener('click', logout);
   document.getElementById('statsBtn').addEventListener('click', viewStats);
+  document.getElementById('activityBtn').addEventListener('click', viewActivity);
   document.getElementById('servicesBtn').addEventListener('click', showServices);
   document.getElementById('contactBtn').addEventListener('click', showContact);
 

--- a/shop-ui/index.html
+++ b/shop-ui/index.html
@@ -19,6 +19,7 @@
                     <button class="btn btn-light me-2" id="contactBtn">Contact</button>
                     <button class="btn btn-light me-2" id="cartBtn">Cart (<span id="cartCount">0</span>)</button>
                     <button class="btn btn-light me-2" id="statsBtn">API Calls</button>
+                    <button class="btn btn-light me-2" id="activityBtn">Activity Log</button>
                     <span id="authSection">
                         <button class="btn btn-success me-2" id="loginBtn">Login</button>
                         <button class="btn btn-danger me-2" id="logoutBtn" style="display:none">Logout</button>


### PR DESCRIPTION
## Summary
- add authenticated `/activity/{username}` API endpoint and query for user audit logs
- surface per-user activity via demo-shop button and server route
- extend admin attack simulation to exfiltrate audit and cart data

## Testing
- `pytest`
- `CI=true npm test`
- `npm test --prefix demo-shop` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68935abe97f8832e82c2c208d230ca29