### PR TITLE
Add admin attack simulation endpoint and controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ server starts your default browser opens the shop home page automatically at
    button which sends `{ "attempts": 50 }` to this route and displays the
    results.
 
+   An additional admin-only route `POST /simulate/admin-attack` drives the
+   dashboard's attack controls. It accepts a JSON payload like
+   `{ "target": "alice", "attempts": 50 }` and returns a summary along with
+   any `compromisedData` such as the user's audit log and cart contents when
+   the attack succeeds.
+
 
 2. Log in and locate the **Credential Stuffing Simulation** section. Choose a
    target account and click **Start Attack**. When targeting Alice the attack

--- a/backend/app/api/demo_shop_sim.py
+++ b/backend/app/api/demo_shop_sim.py
@@ -1,9 +1,19 @@
-from fastapi import APIRouter
-import requests, os
+from typing import Literal
+
+import requests
+import os
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from app.core.db import get_db
+from app.crud.users import get_user_by_username
+from app.crud.audit import get_all_activity_for_user
 
 router = APIRouter()
 
 COMMON_PWS = ["secret", "password", "123456", "ilikepizza"]
+SHOP_URL = os.getenv("DEMO_SHOP_URL", "http://localhost:3005").rstrip("/")
 
 @router.post("/simulate/demo-shop-attack")
 def attack(payload: dict):
@@ -15,3 +25,60 @@ def attack(payload: dict):
             r = requests.post(f"{shop_url}/login", json={"username":"alice","password":pw})
             results.append({"password": pw, "status": r.status_code})
     return {"results": results}
+
+
+class AdminAttackPayload(BaseModel):
+    target: Literal["alice", "ben"]
+    attempts: int
+
+
+@router.post("/simulate/admin-attack")
+def admin_attack(payload: AdminAttackPayload, db: Session = Depends(get_db)):
+    target = payload.target
+    attempts = payload.attempts
+
+    db_user = get_user_by_username(db, target)
+    if db_user and getattr(db_user, "policy", "NoSecurity") == "ZeroTrust":
+        return {"summary": "Attack blocked by policy", "attempts": 0}
+
+    session = requests.Session()
+    success_token = None
+    used_attempts = attempts
+    for i in range(attempts):
+        pw = COMMON_PWS[i % len(COMMON_PWS)]
+        try:
+            resp = session.post(
+                f"{SHOP_URL}/login",
+                json={"username": target, "password": pw},
+                timeout=2,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                success_token = data.get("access_token")
+                used_attempts = i + 1
+                break
+        except Exception:
+            continue
+
+    result = {"summary": "Attack blocked", "attempts": used_attempts}
+    if success_token:
+        cart = None
+        try:
+            cart_resp = session.get(
+                f"{SHOP_URL}/cart",
+                headers={"Authorization": f"Bearer {success_token}"},
+                timeout=2,
+            )
+            if cart_resp.status_code == 200:
+                cart = cart_resp.json()
+        except Exception:
+            cart = None
+
+        activity = [
+            {"event": log.event, "timestamp": log.timestamp.isoformat()}
+            for log in get_all_activity_for_user(db, target)
+        ]
+        result["summary"] = "Attack succeeded"
+        result["compromisedData"] = {"cart": cart, "activity": activity}
+
+    return result

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -140,6 +140,24 @@ function App() {
     }
   };
 
+  async function runAdminAttack() {
+    const targetUser = document.getElementById('attack-target').value;
+    const res = await fetch('http://localhost:8001/simulate/admin-attack', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target: targetUser, attempts: 50 })
+    });
+    const results = await res.json();
+    const resultsDiv = document.getElementById('attack-results');
+    const dataDiv = document.getElementById('compromised-data');
+    resultsDiv.innerText = `Summary: ${results.summary} (Attempts: ${results.attempts})`;
+    if (results.compromisedData) {
+      dataDiv.innerText = JSON.stringify(results.compromisedData, null, 2);
+    } else {
+      dataDiv.innerText = '';
+    }
+  }
+
   return (
     <div className="app-container">
       {/* Dashboard title and logout */}
@@ -209,6 +227,18 @@ function App() {
               </div>
             </div>
           )}
+        </div>
+        <div className="dashboard-card">
+          <div className="attack-controls">
+            <span>Target: </span>
+            <select id="attack-target">
+              <option value="alice">Alice (Weak Policy)</option>
+              <option value="ben">Ben (Strong Policy)</option>
+            </select>
+            <button onClick={runAdminAttack}>Launch Attack</button>
+          </div>
+          <div id="attack-results"></div>
+          <div id="compromised-data"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add `/simulate/admin-attack` route to run credential stuffing against demo shop and return compromised data
- Expose admin dashboard controls to trigger the new simulation
- Document the endpoint in README

## Testing
- `pytest`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68936f108c14832e81f6047e5f543a6a