### PR TITLE
Fix jwt decode import and handle unauthorized security status

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,7 +10,7 @@ import LoginForm from "./LoginForm";
 import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
 import { AuthContext } from "./AuthContext";
-import { jwtDecode } from "jwt-decode";
+import jwtDecode from "jwt-decode";
 import "./App.css";
 import "./Dashboard.css";
 

--- a/frontend/src/SecurityMeter.jsx
+++ b/frontend/src/SecurityMeter.jsx
@@ -12,6 +12,8 @@ export default function SecurityMeter({ username }) {
         if (resp.ok) {
           const data = await resp.json();
           setEnabled(data.enabled);
+        } else if (resp.status === 401 || resp.status === 403) {
+          setError('Not authorized');
         } else {
           setError(await resp.text());
         }


### PR DESCRIPTION
## Summary
- import jwt-decode as a default function to ensure admin tokens are decoded
- show a friendly 'Not authorized' message when non-admin users check security status

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68937723fd10832ebc4c4944e18b27e7