### PR TITLE
Add user activity and security profile endpoints

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from app.core.db import get_db
+from app.api.dependencies import get_current_user
+from app.crud.events import get_user_activity
+from app.crud.users import get_user_by_username
+from app.crud.policies import get_policy_by_id
+from app.schemas.events import EventRead
+
+router = APIRouter(prefix="/api/users", tags=["users"])
+
+
+@router.get("/{username}/activity", response_model=list[EventRead])
+def user_activity(
+    username: str,
+    db: Session = Depends(get_db),
+    _user=Depends(get_current_user),
+):
+    return get_user_activity(db, username)
+
+
+class SecurityProfile(BaseModel):
+    failed_attempts_limit: int
+    mfa_required: bool
+    geo_fencing_enabled: bool
+
+
+@router.get("/{username}/security-profile", response_model=SecurityProfile)
+def user_security_profile(
+    username: str,
+    db: Session = Depends(get_db),
+    _user=Depends(get_current_user),
+):
+    user = get_user_by_username(db, username)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if user.policy_id is None:
+        raise HTTPException(status_code=404, detail="Policy not found")
+
+    policy = get_policy_by_id(db, user.policy_id)
+    if policy is None:
+        raise HTTPException(status_code=404, detail="Policy not found")
+
+    return SecurityProfile(
+        failed_attempts_limit=policy.failed_attempts_limit,
+        mfa_required=policy.mfa_required,
+        geo_fencing_enabled=policy.geo_fencing_enabled,
+    )

--- a/backend/app/crud/events.py
+++ b/backend/app/crud/events.py
@@ -28,3 +28,20 @@ def get_last_logins(db: Session) -> dict[str, datetime]:
         .all()
     )
     return {u: ts for u, ts in rows if u is not None}
+
+
+def get_user_activity(db: Session, username: str, limit: int = 15) -> list[Event]:
+    """Return up to ``limit`` most recent events for a given user.
+
+    The query is ordered by timestamp descending so the newest events are
+    returned first.  A sane default ``limit`` of 15 is applied which satisfies
+    the requirement of returning roughly the 10–15 most recent rows.
+    """
+
+    return (
+        db.query(Event)
+        .filter(Event.username == username)
+        .order_by(Event.timestamp.desc())
+        .limit(limit)
+        .all()
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.api.access_logs import router as access_logs_router
 from app.api.audit import router as audit_router
 from app.api.policies import router as policies_router
 from app.api.demo_shop_sim import router as demo_shop_sim_router
+from app.api.users import router as users_router
 
 app = FastAPI(title="APIShield+")
 
@@ -83,6 +84,7 @@ app.include_router(access_logs_router)  # /api/access-logs
 app.include_router(audit_router)  # /api/audit/log
 app.include_router(policies_router)  # /api/policies and assignments
 app.include_router(demo_shop_sim_router)
+app.include_router(users_router)  # /api/users
 
 
 @app.get("/ping")

--- a/backend/tests/test_users_api.py
+++ b/backend/tests/test_users_api.py
@@ -1,0 +1,71 @@
+import os
+
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+os.environ['SECRET_KEY'] = 'test-secret'
+
+from fastapi.testclient import TestClient  # noqa: E402
+from app.main import app  # noqa: E402
+from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.security import create_access_token, get_password_hash  # noqa: E402
+from app.crud.users import create_user  # noqa: E402
+from app.crud.policies import create_policy  # noqa: E402
+from app.crud.events import create_event  # noqa: E402
+
+client = TestClient(app)
+
+
+def setup_function(_):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    with SessionLocal() as db:
+        lenient = create_policy(db, failed_attempts_limit=5, mfa_required=False, geo_fencing_enabled=False)
+        strict = create_policy(db, failed_attempts_limit=1, mfa_required=True, geo_fencing_enabled=True)
+        create_user(db, username='alice', password_hash=get_password_hash('pw'), policy_id=lenient.id)
+        create_user(db, username='ben', password_hash=get_password_hash('pw'), policy_id=strict.id)
+        for i in range(20):
+            create_event(db, username='alice', action=f'a{i}', success=True)
+        for i in range(12):
+            create_event(db, username='ben', action=f'b{i}', success=False)
+
+
+def teardown_function(_):
+    SessionLocal().close()
+
+
+def auth_header(username: str) -> dict[str, str]:
+    token = create_access_token({'sub': username})
+    return {'Authorization': f'Bearer {token}'}
+
+
+def test_user_activity():
+    resp = client.get('/api/users/alice/activity', headers=auth_header('alice'))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 15
+    assert all(ev['username'] == 'alice' for ev in data)
+
+    resp = client.get('/api/users/ben/activity', headers=auth_header('ben'))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 12
+    assert all(ev['username'] == 'ben' for ev in data)
+
+
+def test_security_profile():
+    resp = client.get('/api/users/alice/security-profile', headers=auth_header('alice'))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {
+        'failed_attempts_limit': 5,
+        'mfa_required': False,
+        'geo_fencing_enabled': False,
+    }
+
+    resp = client.get('/api/users/ben/security-profile', headers=auth_header('ben'))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {
+        'failed_attempts_limit': 1,
+        'mfa_required': True,
+        'geo_fencing_enabled': True,
+    }


### PR DESCRIPTION
## Summary
- add user API exposing recent activity and security profile
- add `get_user_activity` CRUD helper
- register user router in main app
- include tests for activity and security profile endpoints

## Testing
- `pytest backend/tests/test_users_api.py -q`
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68937ef08c1c832ebf289ed0462291e4