### PR TITLE
Add login activity and security profile components

### DIFF
--- a/frontend/src/components/LoginActivity.css
+++ b/frontend/src/components/LoginActivity.css
@@ -1,0 +1,14 @@
+.login-activity {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.login-activity th,
+.login-activity td {
+  border: 1px solid #ccc;
+  padding: 8px;
+}
+
+.login-activity th {
+  background-color: #f2f2f2;
+}

--- a/frontend/src/components/LoginActivity.jsx
+++ b/frontend/src/components/LoginActivity.jsx
@@ -1,0 +1,28 @@
+import './LoginActivity.css';
+
+export default function LoginActivity({ activities = [] }) {
+  if (!activities || activities.length === 0) {
+    return <p>No login activity.</p>;
+  }
+
+  return (
+    <table className="login-activity">
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>IP</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {activities.map((a, idx) => (
+          <tr key={idx}>
+            <td>{a.time || 'Unknown'}</td>
+            <td>{a.ip || 'Unknown'}</td>
+            <td>{a.status || 'Unknown'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/components/LoginActivity.test.jsx
+++ b/frontend/src/components/LoginActivity.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import LoginActivity from './LoginActivity';
+
+test('shows message when no activities', () => {
+  render(<LoginActivity />);
+  expect(screen.getByText(/no login activity/i)).toBeInTheDocument();
+});
+
+test('renders table rows for activities', () => {
+  const data = [{ time: '2024-01-01', ip: '1.1.1.1', status: 'success' }];
+  render(<LoginActivity activities={data} />);
+  expect(screen.getByText('1.1.1.1')).toBeInTheDocument();
+});

--- a/frontend/src/components/SecurityProfile.css
+++ b/frontend/src/components/SecurityProfile.css
@@ -1,0 +1,8 @@
+.security-profile {
+  list-style: none;
+  padding: 0;
+}
+
+.security-profile li {
+  margin-bottom: 4px;
+}

--- a/frontend/src/components/SecurityProfile.jsx
+++ b/frontend/src/components/SecurityProfile.jsx
@@ -1,0 +1,28 @@
+import './SecurityProfile.css';
+
+const humanize = (str) => {
+  const result = str.replace(/([A-Z])/g, ' $1').replace(/_/g, ' ');
+  return result.charAt(0).toUpperCase() + result.slice(1);
+};
+
+export default function SecurityProfile({ profile = {} }) {
+  if (!profile || Object.keys(profile).length === 0) {
+    return <p>No security profile.</p>;
+  }
+
+  const entries = Object.entries(profile);
+  return (
+    <ul className="security-profile">
+      {entries.map(([key, value]) => {
+        if (typeof value === 'boolean') {
+          return (
+            <li key={key}>{`${humanize(key)} is ${value ? 'enabled' : 'disabled'}.`}</li>
+          );
+        }
+        return (
+          <li key={key}>{`${humanize(key)}: ${value ?? 'N/A'}.`}</li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/components/SecurityProfile.test.jsx
+++ b/frontend/src/components/SecurityProfile.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import SecurityProfile from './SecurityProfile';
+
+test('shows message when no profile', () => {
+  render(<SecurityProfile />);
+  expect(screen.getByText(/no security profile/i)).toBeInTheDocument();
+});
+
+test('renders profile fields in plain language', () => {
+  const profile = { mfa: true, passwordRotationDays: 30 };
+  render(<SecurityProfile profile={profile} />);
+  expect(screen.getByText(/mfa is enabled/i)).toBeInTheDocument();
+  expect(screen.getByText(/password rotation days: 30/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add LoginActivity component rendering table of login events with styling
- add SecurityProfile component summarizing policy fields with styling
- test new components for default messages and rendering

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6893839b10c4832eb8fc577a9cb0d6bb