### PR TITLE
feat: add user security widgets to dashboard

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,13 +1,32 @@
 import React, { useEffect, useState } from "react";
+import { jwtDecode } from "jwt-decode";
 import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
+import EventsTable from "../EventsTable";
+import SecurityMeter from "../SecurityMeter";
+import SecurityProfile from "../components/SecurityProfile";
+import LoginActivity from "../components/LoginActivity";
 import { apiFetch, AUTH_TOKEN_KEY } from "../api";
 
 function Dashboard() {
   const [ping, setPing] = useState(null);
   const [refresh, setRefresh] = useState(0);
+  const [activity, setActivity] = useState([]);
+  const [securityProfile, setSecurityProfile] = useState({});
   // Retrieve the authentication token for API requests
   const token = localStorage.getItem(AUTH_TOKEN_KEY);
+
+  let username = null;
+  let role = null;
+  if (token) {
+    try {
+      const decoded = jwtDecode(token);
+      username = decoded.sub;
+      role = decoded.role;
+    } catch (err) {
+      // ignore bad token
+    }
+  }
 
   useEffect(() => {
     apiFetch("/ping")
@@ -16,7 +35,33 @@ function Dashboard() {
       .catch((err) => console.error("Ping failed:", err));
   }, []);
 
+  useEffect(() => {
+    if (role === "user" && username) {
+      apiFetch(`/users/${username}/activity`)
+        .then((res) => res.json())
+        .then((data) => setActivity(data))
+        .catch((err) => console.error("Activity fetch failed:", err));
+      apiFetch(`/users/${username}/security-profile`)
+        .then((res) => res.json())
+        .then((data) => setSecurityProfile(data))
+        .catch((err) => console.error("Profile fetch failed:", err));
+    }
+  }, [role, username]);
+
   const handleNewAlert = () => setRefresh((r) => r + 1);
+
+  if (role === "user") {
+    return (
+      <div style={{ padding: "1rem" }}>
+        <h1>APIShield+ Dashboard</h1>
+        <p>Backend ping says: {ping ?? "Loading…"} </p>
+
+        <SecurityMeter username={username} />
+        <SecurityProfile profile={securityProfile} />
+        <LoginActivity activities={activity} />
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: "1rem" }}>
@@ -28,6 +73,7 @@ function Dashboard() {
       <hr style={{ margin: "2rem 0" }} />
 
       <AlertsTable token={token} refresh={refresh} />
+      <EventsTable />
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import Dashboard from './Dashboard';
+import { apiFetch } from '../api';
+import { jwtDecode } from 'jwt-decode';
+
+jest.mock('../api', () => ({
+  apiFetch: jest.fn(),
+  AUTH_TOKEN_KEY: 'apiShieldAuthToken'
+}));
+
+jest.mock('jwt-decode', () => ({
+  jwtDecode: jest.fn()
+}));
+
+function setupApiMock(username, activityData, profileData) {
+  apiFetch.mockImplementation((path) => {
+    if (path === '/ping') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ message: 'pong' }) });
+    }
+    if (path === `/users/${username}/activity`) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(activityData) });
+    }
+    if (path === `/users/${username}/security-profile`) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(profileData) });
+    }
+    if (path === '/api/security') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ enabled: true }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  apiFetch.mockReset();
+  jwtDecode.mockReset();
+});
+
+test('fetches data and renders security components for Alice', async () => {
+  localStorage.setItem('apiShieldAuthToken', 'token');
+  jwtDecode.mockReturnValue({ sub: 'alice', role: 'user' });
+  setupApiMock('alice', [{ time: 't', ip: '1.1.1.1', status: 'success' }], { mfa: true });
+
+  render(<Dashboard />);
+
+  await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/users/alice/activity'));
+  await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/users/alice/security-profile'));
+
+  expect(await screen.findByText(/mfa is enabled/i)).toBeInTheDocument();
+  expect(await screen.findByText('1.1.1.1')).toBeInTheDocument();
+});
+
+test('fetches data and renders security components for Ben', async () => {
+  localStorage.setItem('apiShieldAuthToken', 'token');
+  jwtDecode.mockReturnValue({ sub: 'ben', role: 'user' });
+  setupApiMock('ben', [{ time: 't', ip: '2.2.2.2', status: 'failure' }], { mfa: false });
+
+  render(<Dashboard />);
+
+  await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/users/ben/activity'));
+  await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/users/ben/security-profile'));
+
+  expect(await screen.findByText(/mfa is disabled/i)).toBeInTheDocument();
+  expect(await screen.findByText('2.2.2.2')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- decode JWT in Dashboard to load user role and username
- fetch and display security profile, login activity, and meter for users
- keep admin alert & event tables intact and add tests for Alice and Ben

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6893859d9020832e99f8ebe361ed3f3f