### PR TITLE
Allow frontend origin for demo-shop login

### DIFF
--- a/demo-shop/package-lock.json
+++ b/demo-shop/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.6.8",
         "body-parser": "^1.20.2",
+        "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-session": "^1.17.3"
       }
@@ -146,6 +147,19 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -605,6 +619,15 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/demo-shop/package.json
+++ b/demo-shop/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "axios": "^1.6.8",
     "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-session": "^1.17.3"
   }

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -4,6 +4,7 @@ const bodyParser = require('body-parser');
 const axios = require('axios');
 const path = require('path');
 const { spawn } = require('child_process');
+const cors = require('cors');
 
 const app = express();
 const PORT = process.env.PORT || 3005;
@@ -20,6 +21,7 @@ if (process.env.API_KEY) {
   api.defaults.headers.common['X-API-Key'] = process.env.API_KEY;
 }
 
+app.use(cors({ origin: 'http://localhost:3000', credentials: true }));
 app.use(bodyParser.json());
 app.use(session({
   secret: 'demo-secret',


### PR DESCRIPTION
## Summary
- allow demo-shop to respond to cross-origin requests from http://localhost:3000 by using `cors`
- add `cors` dependency

## Testing
- `npm test` (fails: Missing script: "test")
- `curl -i -X OPTIONS http://localhost:3005/login -H "Origin: http://localhost:3000" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: content-type"
- `curl -i http://localhost:3005/login -H "Origin: http://localhost:3000" -H "Content-Type: application/json" -d '{"user":"alice","pass":"secret"}'


------
https://chatgpt.com/codex/tasks/task_e_689386e6e20c832eb5050fc7867c28bd