### PR TITLE
Add audit logs table migration

### DIFF
--- a/backend/alembic/versions/df9e776bd3fe_create_audit_logs_table.py
+++ b/backend/alembic/versions/df9e776bd3fe_create_audit_logs_table.py
@@ -1,0 +1,43 @@
+"""create audit logs table
+
+Revision ID: df9e776bd3fe
+Revises: 11111
+Create Date: 2025-08-06 17:44:43.165062
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'df9e776bd3fe'
+down_revision: Union[str, None] = '11111'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("username", sa.String(), nullable=False),
+        sa.Column("event", sa.String(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    with op.batch_alter_table("audit_logs", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_audit_logs_id"), ["id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_audit_logs_username"), ["username"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("audit_logs", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_audit_logs_username"))
+        batch_op.drop_index(batch_op.f("ix_audit_logs_id"))
+
+    op.drop_table("audit_logs")

--- a/backend/app/models/audit_logs.py
+++ b/backend/app/models/audit_logs.py
@@ -1,9 +1,15 @@
+"""SQLAlchemy model for storing audit log entries."""
+
 from datetime import datetime
+
 from sqlalchemy import Column, Integer, String, DateTime
+
 from app.core.db import Base
 
 
 class AuditLog(Base):
+    """Record of an event triggered by a user for auditing purposes."""
+
     __tablename__ = "audit_logs"
 
     id = Column(Integer, primary_key=True, index=True)


### PR DESCRIPTION
## Summary
- document the AuditLog SQLAlchemy model
- add alembic migration creating an `audit_logs` table

## Testing
- `alembic upgrade head`
- `sqlite3 app.db '.tables'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893938fb180832eb87efe24a74d5ae7