### PR TITLE
Ensure security tables and audit logs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,8 @@ from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 import os
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-from .core.db import engine # Import the engine from your db setup
-from . import models # Import your models
+from .core.db import engine  # Import the engine from your db setup
+from . import models  # Import your models
 
 from app.core.zero_trust import ZeroTrustMiddleware
 from app.core.logging import APILoggingMiddleware
@@ -29,6 +29,12 @@ from app.api.demo_shop_sim import router as demo_shop_sim_router
 from app.api.users import router as users_router
 
 app = FastAPI(title="APIShield+")
+
+
+@app.on_event("startup")
+def create_tables() -> None:
+    """Ensure all database tables are created at startup."""
+    models.Base.metadata.create_all(bind=engine)
 
 # Permit requests from local development frontends
 default_origins = [

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from pydantic import BaseModel
+from pydantic import BaseModel, constr
 
 
 class AuditEventType(str, Enum):
@@ -14,7 +14,7 @@ class AuditEventType(str, Enum):
 
 class AuditLogCreate(BaseModel):
     event: AuditEventType
-    username: str  # required
+    username: constr(min_length=1)
 
 
 class AuditLogRead(AuditLogCreate):


### PR DESCRIPTION
## Summary
- create database tables on startup so security state model exists
- require non-empty usernames for audit logs and propagate username from demo shop frontend

## Testing
- `pytest` *(fails: tests/test_users_api.py::test_user_activity - assert 0 == 15)*
- `pytest tests/test_audit.py`
- `node --check demo-shop/server.js`


------
https://chatgpt.com/codex/tasks/task_e_689396435010832e85fe262839c8f67e