### PR TITLE
Document API_KEY requirement for demo shop

### DIFF
--- a/demo-shop/README.md
+++ b/demo-shop/README.md
@@ -5,6 +5,7 @@ It can integrate with the APIShield+ backend for additional telemetry. By defaul
 this forwarding is **enabled** so events reach the API unless explicitly disabled.
 Set the environment variable `FORWARD_API=false` to run the shop standalone without API calls. Requests to the API use a short timeout controlled by `API_TIMEOUT_MS` (default `2000`). Set `REAUTH_PER_REQUEST=true` if you want the shop to require the password on every request.
 Each protected endpoint checks the `X-Reauth-Password` header only when this option is enabled, and it is disabled by default so the shop behaves like a normal session-based app.
+Provide your `ZERO_TRUST_API_KEY` via the `API_KEY` environment variable so API calls include the required authentication.
 
 The server pre-registers demo accounts so you can log in immediately with
 `alice`/`secret` or `ben`/`ILikeN1G3R!A##?`.
@@ -17,7 +18,7 @@ same authentication state.
 ```
 cd demo-shop
 npm install
-node server.js
+API_KEY=<your ZERO_TRUST_API_KEY> node server.js
 ```
 
 When running in Kubernetes, after port-forwarding the services:

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -15,10 +15,15 @@ const API_TIMEOUT = parseInt(process.env.API_TIMEOUT_MS || '2000', 10);
 // Disable backend integration entirely by setting FORWARD_API=false.
 const FORWARD_API = process.env.FORWARD_API !== 'false';
 const REAUTH_PER_REQUEST = process.env.REAUTH_PER_REQUEST === 'true';
+const API_KEY = process.env.API_KEY;
+if (FORWARD_API && !API_KEY) {
+  console.error('Missing API_KEY environment variable. Set your ZERO_TRUST_API_KEY before starting the demo shop.');
+  process.exit(1);
+}
 
 const api = axios.create({ baseURL: API_BASE, timeout: API_TIMEOUT });
-if (process.env.API_KEY) {
-  api.defaults.headers.common['X-API-Key'] = process.env.API_KEY;
+if (API_KEY) {
+  api.defaults.headers.common['X-API-Key'] = API_KEY;
 }
 
 app.use(cors({ origin: 'http://localhost:3000', credentials: true }));


### PR DESCRIPTION
## Summary
- enforce presence of `API_KEY` when forwarding to APIShield and set header automatically
- clarify in demo shop README that the server must be started with `API_KEY=<your ZERO_TRUST_API_KEY>`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893997692c8832eba665e04d6c71155