### PR TITLE
Ensure models are loaded before creating tables

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,8 @@ from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 import os
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-from .core.db import engine  # Import the engine from your db setup
-from . import models  # Import your models
+from app.core.db import engine, Base
+from app import models  # noqa: F401  # Ensure models are registered
 
 from app.core.zero_trust import ZeroTrustMiddleware
 from app.core.logging import APILoggingMiddleware
@@ -34,7 +34,8 @@ app = FastAPI(title="APIShield+")
 @app.on_event("startup")
 def create_tables() -> None:
     """Ensure all database tables are created at startup."""
-    models.Base.metadata.create_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
 
 # Permit requests from local development frontends
 # Additional origins can be supplied via the ALLOW_ORIGINS env var


### PR DESCRIPTION
## Summary
- Import SQLAlchemy `Base` alongside `engine`
- Load model modules before creating tables
- Use `Base.metadata.create_all` for startup table creation

## Testing
- `flake8 backend/app/main.py`
- `cd backend && pytest` *(fails: tests/test_users_api.py::test_user_activity)*

------
https://chatgpt.com/codex/tasks/task_e_68939af456c0832eb60283fabe385d0c