### PR TITLE
Fix Base import and generalize user activity retrieval

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -18,7 +18,7 @@ def user_activity(
     db: Session = Depends(get_db),
     _user=Depends(get_current_user),
 ):
-    return get_user_activity(db, username)
+    return get_user_activity(db, username, action=None)
 
 
 class SecurityProfile(BaseModel):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,8 @@ from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 import os
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-from .core.db import engine  # Import the engine from your db setup
-from . import models  # Import your models
+from .core.db import engine, Base  # Import the engine and Base
+from . import models  # Import your models to register tables
 
 from app.core.zero_trust import ZeroTrustMiddleware
 from app.core.logging import APILoggingMiddleware
@@ -34,7 +34,7 @@ app = FastAPI(title="APIShield+")
 @app.on_event("startup")
 def create_tables() -> None:
     """Ensure all database tables are created at startup."""
-    models.Base.metadata.create_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
 
 # Permit requests from local development frontends
 # Additional origins can be supplied via the ALLOW_ORIGINS env var


### PR DESCRIPTION
## Summary
- import SQLAlchemy Base from the central db module and use it to create tables
- make `get_user_activity` accept optional action filter and include all events in `/api/users/{username}/activity`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68939b2b8a68832ea94d5c0edbcac075