### PR TITLE
Document API key requirement for demo shop

### DIFF
--- a/demo-shop/README.md
+++ b/demo-shop/README.md
@@ -5,7 +5,11 @@ It can integrate with the APIShield+ backend for additional telemetry. By defaul
 this forwarding is **enabled** so events reach the API unless explicitly disabled.
 Set the environment variable `FORWARD_API=false` to run the shop standalone without API calls. Requests to the API use a short timeout controlled by `API_TIMEOUT_MS` (default `2000`). Set `REAUTH_PER_REQUEST=true` if you want the shop to require the password on every request.
 Each protected endpoint checks the `X-Reauth-Password` header only when this option is enabled, and it is disabled by default so the shop behaves like a normal session-based app.
-Provide your `ZERO_TRUST_API_KEY` via the `API_KEY` environment variable so API calls include the required authentication.
+Provide your `ZERO_TRUST_API_KEY` via the `API_KEY` environment variable so API calls include the required authentication. Start the server with:
+
+```
+API_KEY=<your ZERO_TRUST_API_KEY> node server.js
+```
 
 The server pre-registers demo accounts so you can log in immediately with
 `alice`/`secret` or `ben`/`ILikeN1G3R!A##?`.
@@ -18,6 +22,7 @@ same authentication state.
 ```
 cd demo-shop
 npm install
+# Provide your ZERO_TRUST_API_KEY when starting the server
 API_KEY=<your ZERO_TRUST_API_KEY> node server.js
 ```
 

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -15,9 +15,12 @@ const API_TIMEOUT = parseInt(process.env.API_TIMEOUT_MS || '2000', 10);
 // Disable backend integration entirely by setting FORWARD_API=false.
 const FORWARD_API = process.env.FORWARD_API !== 'false';
 const REAUTH_PER_REQUEST = process.env.REAUTH_PER_REQUEST === 'true';
+// ZERO_TRUST_API_KEY used for authenticating backend requests
 const API_KEY = process.env.API_KEY;
 if (FORWARD_API && !API_KEY) {
-  console.error('Missing API_KEY environment variable. Set your ZERO_TRUST_API_KEY before starting the demo shop.');
+  console.error(
+    'Missing API_KEY environment variable. Start the shop with `API_KEY=<your ZERO_TRUST_API_KEY> node server.js`.'
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- enforce API_KEY env var and provide startup command guidance in demo shop server
- document API_KEY usage in demo shop README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68939cb12178832e85a151b646b305ef