### PR TITLE
Ensure models registered before table creation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,6 @@ from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 import os
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-from .core.db import engine, Base  # Import the engine and Base
-from . import models  # Import your models to register tables
 from app.core.db import engine, Base
 from app import models  # noqa: F401  # Ensure models are registered
 


### PR DESCRIPTION
## Summary
- import engine and Base from app.core.db in `main.py`
- register all models before creating tables with `Base.metadata.create_all`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68939fa22884832ebb266adf10c05314