### PR TITLE
Fix SQLAlchemy initialization

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,6 @@ from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 import os
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-from .core.db import engine, Base  # Import the engine and Base
-from . import models  # Import your models to register tables
 from app.core.db import engine, Base
 from app import models  # noqa: F401  # Ensure models are registered
 


### PR DESCRIPTION
## Summary
- Import SQLAlchemy `engine` and `Base` from `app.core.db`
- Ensure models are loaded before creating database tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a2db5ac4832e8492c8bf51903372