### PR TITLE
Allow demo shop from all local origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,7 @@
 DATABASE_URL=sqlite:///./app.db
 SECRET_KEY=super-secret-key
 # Comma-separated list of hosts allowed by CORS (include demo-shop port)
-ALLOW_ORIGINS=http://localhost:8001,http://localhost:3000,http://localhost:3005
+ALLOW_ORIGINS=http://localhost:8001,http://localhost:3000,http://localhost:3005,http://127.0.0.1:3000,http://127.0.0.1:3005
 # Optional tuning parameters
 FAIL_LIMIT=5
 FAIL_WINDOW_SECONDS=60

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -29,7 +29,17 @@ if (API_KEY) {
   api.defaults.headers.common['X-API-Key'] = API_KEY;
 }
 
-app.use(cors({ origin: 'http://localhost:3000', credentials: true }));
+app.use(
+  cors({
+    origin: [
+      'http://localhost:3000',
+      'http://localhost:3005',
+      'http://127.0.0.1:3000',
+      'http://127.0.0.1:3005'
+    ],
+    credentials: true
+  })
+);
 app.use(bodyParser.json());
 app.use(session({
   secret: 'demo-secret',


### PR DESCRIPTION
## Summary
- allow demo shop to accept requests from localhost and 127.0.0.1 on ports 3000 and 3005
- document matching origins in backend `.env.example`

## Testing
- `cd demo-shop && npm test` (fails: Missing script: "test")
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68940ba0f038832e936537cc7488a0d4