### PR TITLE
Send username with audit events in shop UI

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -46,7 +46,7 @@ async function logAuditEvent(event) {
     await fetch(AUDIT_URL, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ event })
+      body: JSON.stringify({ event, username })
     });
   } catch (e) {
     // ignore logging errors


### PR DESCRIPTION
## Summary
- include the current username when the shop UI logs audit events to the API so logs are accepted

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68944c4bca7c832e89d716282acc2090