### PR TITLE
Improve demo attack flow and auth handling in dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,7 +19,7 @@ function App() {
 
   const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
-  const [policy, setPolicy] = useState(null);
+  const [zeroTrustEnabled, setZeroTrustEnabled] = useState(null);
   const [attackStatus, setAttackStatus] = useState(null);
   const [compromisedData, setCompromisedData] = useState(null);
   const { user, setUser } = useContext(AuthContext);
@@ -41,7 +41,7 @@ function App() {
     localStorage.removeItem(USERNAME_KEY);
     await logAuditEvent("user_logout", username);
     setToken(null);
-    setPolicy(null);
+    setZeroTrustEnabled(null);
     setAttackStatus(null);
     setCompromisedData(null);
     setUser(null);
@@ -71,7 +71,7 @@ function App() {
             <LoginForm
               onLogin={(tok, pol) => {
                 setToken(tok);
-                setPolicy(pol);
+                setZeroTrustEnabled(pol === "ZeroTrust");
               }}
             />
           </div>
@@ -110,7 +110,7 @@ function App() {
   const runDemoShopAttack = async () => {
     setAttackStatus("Running attack…");
     setCompromisedData(null);
-    const user = policy === "ZeroTrust" ? "ben" : "alice";
+    const user = zeroTrustEnabled ? "ben" : "alice";
     try {
       const resp = await apiFetch("/simulate/demo-shop-attack", {
         method: "POST",
@@ -179,13 +179,13 @@ function App() {
           />
         </div>
         <div className="dashboard-card">
-          <AlertsChart token={token} />
+          <AlertsChart />
         </div>
         <div className="dashboard-card">
-          <AlertsTable refresh={refreshKey} token={token} />
+          <AlertsTable refresh={refreshKey} />
         </div>
         <div className="dashboard-card">
-          <EventsTable token={token} />
+          <EventsTable />
         </div>
         <div className="dashboard-card">
           <h2>Alice’s Security Status</h2>
@@ -197,14 +197,14 @@ function App() {
         </div>
         <div className="dashboard-card">
           <div className="attack-section">
-            {policy === "NoSecurity" && (
+            {zeroTrustEnabled === false && (
               <button onClick={runDemoShopAttack}>Attack Demo Shop (Alice)</button>
             )}
-            {policy === "ZeroTrust" && (
+            {zeroTrustEnabled === true && (
               <button onClick={runDemoShopAttack}>Attack Demo Shop (Ben)</button>
             )}
             <div className="security-box">
-              <SecurityToggle />
+              <SecurityToggle forcedState={zeroTrustEnabled} />
             </div>
           </div>
           {attackStatus && <p>{attackStatus}</p>}

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -12,7 +12,7 @@ const DUMMY_PASSWORDS = [
   "letmein",
 ];
 
-export default function AttackSim({ user, token }) {
+export default function AttackSim({ user }) {
   const [targetUser, setTargetUser] = useState(user || "alice");
 
   useEffect(() => {
@@ -339,7 +339,7 @@ export default function AttackSim({ user, token }) {
         </div>
       )}
       <div className="attack-alerts">
-        <AlertsChart token={token} />
+        <AlertsChart />
       </div>
       <div style={{ marginTop: "1rem" }}>
         <button onClick={runDemoShopAttack}>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -96,7 +96,7 @@ function Dashboard() {
 
       <hr style={{ margin: "2rem 0" }} />
 
-      <AlertsTable token={token} refresh={refresh} />
+      <AlertsTable refresh={refresh} />
       <EventsTable />
 
       {/* Per-user security statistics */}
@@ -120,7 +120,7 @@ function Dashboard() {
       <div
         style={{ marginTop: "2rem", padding: "1rem", border: "1px solid #ccc" }}
       >
-        <AttackSim token={token} />
+        <AttackSim />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Track zero-trust state in the app, clearing it on logout and passing it to SecurityToggle
- Route demo-shop attack button through `/simulate/demo-shop-attack` and show results
- Drop redundant Authorization token props and rely on `apiFetch` for headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68944dd87ad8832e977869fe8b7691f9