### PR TITLE
Ensure charts and tables use current auth token

### DIFF
--- a/frontend/src/AlertsChart.jsx
+++ b/frontend/src/AlertsChart.jsx
@@ -22,7 +22,7 @@ ChartJS.register(
   Legend
 );
 
-export default function AlertsChart() {
+export default function AlertsChart({ token }) {
   const [stats, setStats] = useState([]);
   const [error, setError] = useState(null);
 
@@ -38,9 +38,10 @@ export default function AlertsChart() {
   };
 
   useEffect(() => {
-    loadStats();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (token) {
+      loadStats();
+    }
+  }, [token]);
 
   if (error) return <p className="error-text">{error}</p>;
   if (stats.length === 0) return <p>No data yet.</p>;

--- a/frontend/src/AlertsTable.jsx
+++ b/frontend/src/AlertsTable.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function AlertsTable({ refresh }) {
+export default function AlertsTable({ refresh, token }) {
   const [alerts, setAlerts] = useState([]);
   const [error, setError] = useState(null);
 
@@ -16,10 +16,12 @@ export default function AlertsTable({ refresh }) {
     }
   };
 
-  // reload when component mounts or when `refresh` changes
+  // reload when component mounts or when `refresh` or `token` changes
   useEffect(() => {
-    loadAlerts();
-  }, [refresh]);
+    if (token) {
+      loadAlerts();
+    }
+  }, [refresh, token]);
 
   if (error) return <p className="error-text">{error}</p>;
   if (alerts.length === 0) return <p>No alerts yet.</p>;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -179,13 +179,13 @@ function App() {
           />
         </div>
         <div className="dashboard-card">
-          <AlertsChart />
+          <AlertsChart token={token} />
         </div>
         <div className="dashboard-card">
-          <AlertsTable refresh={refreshKey} />
+          <AlertsTable refresh={refreshKey} token={token} />
         </div>
         <div className="dashboard-card">
-          <EventsTable />
+          <EventsTable token={token} />
         </div>
         <div className="dashboard-card">
           <h2>Alice’s Security Status</h2>

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -339,7 +339,7 @@ export default function AttackSim({ user }) {
         </div>
       )}
       <div className="attack-alerts">
-        <AlertsChart />
+        <AlertsChart token={localStorage.getItem(AUTH_TOKEN_KEY)} />
       </div>
       <div style={{ marginTop: "1rem" }}>
         <button onClick={runDemoShopAttack}>

--- a/frontend/src/EventsTable.jsx
+++ b/frontend/src/EventsTable.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function EventsTable() {
+export default function EventsTable({ token }) {
   const [events, setEvents] = useState([]);
   const [error, setError] = useState(null);
   const [hours, setHours] = useState(24);
@@ -19,9 +19,10 @@ export default function EventsTable() {
   };
 
   useEffect(() => {
-    load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hours]);
+    if (token) {
+      load();
+    }
+  }, [hours, token]);
 
   if (error) return <p className="error-text">{error}</p>;
   if (events.length === 0) return <p>No events.</p>;

--- a/frontend/src/UserAccounts.jsx
+++ b/frontend/src/UserAccounts.jsx
@@ -33,8 +33,6 @@ export default function UserAccounts({ onSelect }) {
     onSelect?.(username);
   };
 
-  const selected = USER_DATA[active];
-
   return (
     <div className="user-accounts">
       <div className="btn-group mb-3">
@@ -49,28 +47,35 @@ export default function UserAccounts({ onSelect }) {
           </button>
         ))}
       </div>
-      <div className="card">
-        <div className="card-body">
-          <h3 className="card-title">{selected.name} Security</h3>
-          <div className="security-meter mb-3">
-            <div
-              className={`security-meter-bar ${
-                selected.security < 50 ? "low-security" : "high-security"
-              }`}
-              style={{ width: `${selected.security}%` }}
-            >
-              {selected.security}%
+      {Object.entries(USER_DATA).map(([username, data]) => (
+        <div
+          key={username}
+          id={`user-card-${username}`}
+          className="card"
+          style={{ display: active === username ? "block" : "none" }}
+        >
+          <div className="card-body">
+            <h3 className="card-title">{data.name} Security</h3>
+            <div className="security-meter mb-3">
+              <div
+                className={`security-meter-bar ${
+                  data.security < 50 ? "low-security" : "high-security"
+                }`}
+                style={{ width: `${data.security}%` }}
+              >
+                {data.security}%
+              </div>
             </div>
           </div>
+          <ul className="list-group list-group-flush">
+            {data.features.map((feature) => (
+              <li key={feature} className="list-group-item">
+                {feature}
+              </li>
+            ))}
+          </ul>
         </div>
-        <ul className="list-group list-group-flush">
-          {selected.features.map((feature) => (
-            <li key={feature} className="list-group-item">
-              {feature}
-            </li>
-          ))}
-        </ul>
-      </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- forward JWT token to AlertsChart, AlertsTable, and EventsTable so data loads with proper authorization
- wrap UserAccounts cards in keyed `<div>` elements to fix rendering
- refresh chart in attack simulator with stored token

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6894528c653c832eb924cab2c08ccf3f