### PR TITLE
feat: extend demo shop simulation and admin attack UI

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -200,11 +200,12 @@ app.get('/products', (req, res) => {
   res.json(products);
 });
 
-app.post('/cart', requireAuth, (req, res) => {
+app.post('/cart', requireAuth, async (req, res) => {
   const { productId } = req.body;
   const product = products.find(p => p.id === productId);
   if (!product) return res.status(404).json({ error: 'not found' });
   users[req.session.username].cart.push(product);
+  await sendAuditLog(req, 'shop_add_to_cart');
   res.json({ status: 'added' });
 });
 
@@ -231,8 +232,9 @@ app.get('/cart', async (req, res) => {
   }
 });
 
-app.post('/purchase', requireAuth, (req, res) => {
+app.post('/purchase', requireAuth, async (req, res) => {
   users[req.session.username].cart = [];
+  await sendAuditLog(req, 'shop_purchase');
   res.json({ status: 'purchased' });
 });
 


### PR DESCRIPTION
## Summary
- allow React dashboard to run full demo shop and admin attacks
- add audit log events for cart additions and purchases

## Testing
- `pytest`
- `npm test --silent -- --watchAll=false` in `frontend`
- `npm test` (fails: Missing script: "test") in `demo-shop`


------
https://chatgpt.com/codex/tasks/task_e_6894546be1f8832e86793ee37ba0aac3