### PR TITLE
Track username in stuffing_attempt events

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -94,6 +94,7 @@ def login(user_in: UserCreate, request: Request, db: Session = Depends(get_db)):
             db,
             request.client.host,
             False,
+            username=user_in.username,
             user_id=user.id if user else None,
             fail_limit=fail_limit,
         )
@@ -120,6 +121,7 @@ def login(user_in: UserCreate, request: Request, db: Session = Depends(get_db)):
         db,
         request.client.host,
         True,
+        username=user_in.username,
         user_id=user.id,
         fail_limit=fail_limit,
     )

--- a/backend/app/api/score.py
+++ b/backend/app/api/score.py
@@ -69,6 +69,7 @@ def record_attempt(
     *,
     with_jwt: bool = False,
     detail: str | None = None,
+    username: str | None = None,
     user_id: int | None = None,
     fail_limit: int | None = None,
 ) -> Dict[str, Any]:
@@ -107,9 +108,9 @@ def record_attempt(
             attempts = attempts[-fail_limit:]
         FAILED_USER_ATTEMPTS[user_id] = attempts
 
-    # Record the failed attempt for the event log.  The username is unknown at
-    # this stage so ``None`` is stored.
-    log_event(db, None, "stuffing_attempt", False)
+    # Record the failed attempt for the event log.  Include the username when
+    # available so the dashboard can attribute the attack to a specific user.
+    log_event(db, username, "stuffing_attempt", False)
 
     if security.is_enabled(db) and fail_count >= ip_fail_limit:
         STUFFING_DETECTIONS.labels(ip=client_ip).inc()

--- a/backend/app/core/re_auth.py
+++ b/backend/app/core/re_auth.py
@@ -45,6 +45,7 @@ class ReAuthMiddleware(BaseHTTPMiddleware):
                     client_ip,
                     False,
                     detail="Password required",
+                    username=username,
                 )
                 log_event(db, username, "reauth", False)
             return JSONResponse(
@@ -59,6 +60,7 @@ class ReAuthMiddleware(BaseHTTPMiddleware):
                     request.client.host if request.client else "unknown",
                     False,
                     detail="Invalid credentials",
+                    username=username,
                     with_jwt=True,
                 )
                 log_event(db, username, "reauth", False)


### PR DESCRIPTION
## Summary
- capture usernames for credential stuffing attempts
- propagate usernames through login and re-auth logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689460d574a0832e87d69cfb7cf317ac