### PR TITLE
Wrap audit log failures in login form

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -26,11 +26,11 @@ export default function LoginForm({ onLogin }) {
         credentials: "include",
         body: JSON.stringify({ username, password }),
       });
-      await logAuditEvent("user_login_success", username);
+      await logAuditEvent({ event: "user_login_success", username }).catch(() => {});
       onLogin(data.access_token, data.policy);
     } catch (err) {
       console.error("Login failed:", err.message);
-      await logAuditEvent("user_login_failure", username);
+      await logAuditEvent({ event: "user_login_failure", username }).catch(() => {});
       setError(err.message || "An unexpected error occurred.");
     }
   };


### PR DESCRIPTION
## Summary
- Log login success/failure using object-form audit events
- Guard audit logging with `.catch` so failures don't break login flow

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689478ad2d54832eb8e2491060d904d8