### PR TITLE
Fix logout audit payload

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,7 +41,7 @@ function App() {
     const username = localStorage.getItem(USERNAME_KEY);
     localStorage.removeItem(AUTH_TOKEN_KEY);
     localStorage.removeItem(USERNAME_KEY);
-    await logAuditEvent("user_logout", username);
+    await logAuditEvent({ event: "user_logout", username }).catch(() => {});
     setToken(null);
     setZeroTrustEnabled(null);
     setAttackStatus(null);


### PR DESCRIPTION
## Summary
- send structured logout event with username to audit API
- ignore audit log failures to avoid uncaught errors

## Testing
- `cd frontend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68947c051c88832eae4de72568bd7341