### PR TITLE
Log username in logout audit

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,7 +41,7 @@ function App() {
     const username = localStorage.getItem(USERNAME_KEY);
     localStorage.removeItem(AUTH_TOKEN_KEY);
     localStorage.removeItem(USERNAME_KEY);
-    await logAuditEvent("user_logout", username);
+    await logAuditEvent({ event: "user_logout", username }).catch(() => {});
     setToken(null);
     setZeroTrustEnabled(null);
     setAttackStatus(null);


### PR DESCRIPTION
## Summary
- log logout event with username for audit service
- guard logout audit to avoid unhandled errors

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68947d040398832ebbe0cd4e86c5e387