### PR TITLE
Ensure audit logs have valid usernames

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,7 +41,9 @@ function App() {
     const username = localStorage.getItem(USERNAME_KEY);
     localStorage.removeItem(AUTH_TOKEN_KEY);
     localStorage.removeItem(USERNAME_KEY);
-    await logAuditEvent({ event: "user_logout", username }).catch(() => {});
+    if (username) {
+      await logAuditEvent({ event: "user_logout", username }).catch(() => {});
+    }
     setToken(null);
     setZeroTrustEnabled(null);
     setAttackStatus(null);

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -26,11 +26,13 @@ export default function LoginForm({ onLogin }) {
         credentials: "include",
         body: JSON.stringify({ username, password }),
       });
-      await logAuditEvent({ event: "user_login_success", username }).catch(() => {});
+      const safeUsername = username || "unknown";
+      await logAuditEvent({ event: "user_login_success", username: safeUsername }).catch(() => {});
       onLogin(data.access_token, data.policy);
     } catch (err) {
       console.error("Login failed:", err.message);
-      await logAuditEvent({ event: "user_login_failure", username }).catch(() => {});
+      const safeUsername = username || "unknown";
+      await logAuditEvent({ event: "user_login_failure", username: safeUsername }).catch(() => {});
       setError(err.message || "An unexpected error occurred.");
     }
   };

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -43,10 +43,23 @@ export function apiFetch(path, options = {}) {
 }
 
 // Helper function for logging events, which now also uses the authenticated apiFetch.
-export function logAuditEvent(event) {
+const VALID_EVENTS = new Set([
+  'user_login_success',
+  'user_login_failure',
+  'user_logout',
+]);
+
+export function logAuditEvent(payload = {}) {
+  const { event, username } = payload;
+  if (!VALID_EVENTS.has(event)) {
+    return Promise.resolve();
+  }
+  if (typeof username !== 'string' || username.trim() === '') {
+    return Promise.resolve();
+  }
   return apiFetch('/api/audit/log', {
     method: 'POST',
-    body: JSON.stringify(event),
+    body: JSON.stringify({ event, username }),
   });
 }
 

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -36,7 +36,16 @@ async function fetchJSON(url, options = {}) {
   return res.json();
 }
 
+const VALID_EVENTS = new Set([
+  'user_login_success',
+  'user_login_failure',
+  'user_logout',
+]);
+
 async function logAuditEvent(event) {
+  if (!VALID_EVENTS.has(event) || !username) {
+    return;
+  }
   const token = localStorage.getItem(AUTH_TOKEN_KEY);
   const headers = { 'Content-Type': 'application/json' };
   if (token) {
@@ -173,7 +182,9 @@ function showLogin() {
           noAuth: true
         });
         localStorage.setItem(AUTH_TOKEN_KEY, data.access_token);
-        await logAuditEvent('user_login_success');
+        if (username) {
+          await logAuditEvent('user_login_success');
+        }
         document.getElementById('loginBtn').style.display = 'none';
         document.getElementById('logoutBtn').style.display = 'inline-block';
         updateCartCount();
@@ -253,7 +264,9 @@ async function logout() {
     showMessage('Logout failed', true);
     return;
   }
-  await logAuditEvent('user_logout');
+  if (username) {
+    await logAuditEvent('user_logout');
+  }
   username = null;
   // remove any stored auth token so other apps reflect logout
   localStorage.removeItem(AUTH_TOKEN_KEY);


### PR DESCRIPTION
## Summary
- Guard logout audit logging behind a username check
- Ensure login audit events supply a default username
- Validate audit event payloads before sending
- Harden shop-ui audit logging to require valid events and usernames

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68947f4cc574832e95dda3df7d5cebf4