### PR TITLE
feat(frontend): stream audit events to dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import UserAccounts from "./UserAccounts";
 import LoginStatus from "./LoginStatus";
 import { AuthContext } from "./AuthContext";
 import  jwtDecode  from "jwt-decode";
+import AuditFeed from "./AuditFeed";
 import "./App.css";
 import "./Dashboard.css";
 
@@ -187,6 +188,9 @@ function App() {
         </div>
         <div className="dashboard-card">
           <EventsTable token={token} />
+        </div>
+        <div className="dashboard-card">
+          <AuditFeed />
         </div>
         <div className="dashboard-card">
           <h2>Alice’s Security Status</h2>

--- a/frontend/src/AuditFeed.jsx
+++ b/frontend/src/AuditFeed.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+const WS_URL = process.env.REACT_APP_AUDIT_WS_URL || "ws://localhost:8001/api/audit/ws";
+
+export default function AuditFeed() {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    const ws = new WebSocket(WS_URL);
+    ws.onmessage = (msg) => {
+      try {
+        const data = JSON.parse(msg.data);
+        if (data.event) {
+          setEvents((prev) => [data.event, ...prev].slice(0, 50));
+        }
+      } catch (e) {
+        // ignore malformed messages
+      }
+    };
+    return () => ws.close();
+  }, []);
+
+  if (events.length === 0) {
+    return <p>No audit events yet.</p>;
+  }
+
+  return (
+    <div>
+      <h3>Audit Events</h3>
+      <ul>
+        {events.map((e, idx) => (
+          <li key={idx}>{e}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add AuditFeed component using `ws://localhost:8001/api/audit/ws`
- display audit events on admin dashboard

## Testing
- `CI=true npm test -- --watchAll=false`
- Python websocket check: received `{\"event\":\"user_login_success\"}` from `/api/audit/ws`


------
https://chatgpt.com/codex/tasks/task_e_689481c13ce4832e8426fc1e02959006