### PR TITLE
Support dynamic origins for demo shop UI

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -15,6 +15,25 @@ const API_TIMEOUT = parseInt(process.env.API_TIMEOUT_MS || '2000', 10);
 const FORWARD_API = process.env.FORWARD_API === 'true';
 const REAUTH_PER_REQUEST = process.env.REAUTH_PER_REQUEST === 'true';
 
+// Allow cross-origin requests from common local hosts so cookies work
+// when accessing the UI via different domains/ports.
+const allowedOrigins = (process.env.ALLOWED_ORIGINS ||
+  'http://localhost:3005,http://127.0.0.1:3005').split(',');
+
+app.use((req, res, next) => {
+  const origin = req.get('origin');
+  if (allowedOrigins.includes(origin)) {
+    res.header('Access-Control-Allow-Origin', origin);
+    res.header('Access-Control-Allow-Credentials', 'true');
+  }
+  res.header('Access-Control-Allow-Headers', 'Content-Type, X-Reauth-Password');
+  res.header('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
 app.use(bodyParser.json());
 app.use(session({
   secret: 'demo-secret',

--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -1,4 +1,5 @@
-const API_BASE = 'http://localhost:3005';
+// Use the current browser origin so the API shares cookies across hosts/ports
+const API_BASE = window.location.origin;
 let username = null;
 
 function setContent(html) {
@@ -9,7 +10,7 @@ function setContent(html) {
 
 async function fetchJSON(url, options = {}) {
   const { noAuth, ...opts } = options;
-  const fetchOpts = { headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', ...opts };
+  const fetchOpts = { headers: { 'Content-Type': 'application/json' }, credentials: 'include', ...opts };
   if (!noAuth) {
     const pw = prompt('Please re-enter your password');
     if (pw === null) throw new Error('Password required');


### PR DESCRIPTION
## Summary
- Use the browser's current origin for API calls instead of a fixed `localhost` URL
- Always include credentials in fetch requests
- Allow the demo shop server to send CORS headers for common local origins

## Testing
- `curl -i -c /tmp/cookie_localhost.txt -H 'Content-Type: application/json' -H 'Origin: http://localhost:3005' -d '{"username":"alice","password":"secret"}' http://localhost:3005/login`
- `curl -b /tmp/cookie_localhost.txt http://localhost:3005/session; echo`
- `curl -i -c /tmp/cookie_127.txt -H 'Content-Type: application/json' -H 'Origin: http://127.0.0.1:3005' -d '{"username":"alice","password":"secret"}' http://127.0.0.1:3005/login`
- `curl -b /tmp/cookie_127.txt http://127.0.0.1:3005/session; echo`


------
https://chatgpt.com/codex/tasks/task_e_6894d866f200832e8067c135ab2be764