### PR TITLE
Add security state table migration

### DIFF
--- a/backend/alembic/versions/0b9e06985bd8_create_security_state_table.py
+++ b/backend/alembic/versions/0b9e06985bd8_create_security_state_table.py
@@ -1,0 +1,40 @@
+"""create security_state table
+
+Revision ID: 0b9e06985bd8
+Revises: fffff
+Create Date: 2025-08-08 11:33:43.543013
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0b9e06985bd8'
+down_revision: Union[str, None] = 'fffff'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "security_state",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("security_enabled", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("current_chain", sa.String(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_security_state_id"),
+        "security_state",
+        ["id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_security_state_id"), table_name="security_state")
+    op.drop_table("security_state")


### PR DESCRIPTION
## Summary
- add Alembic migration for new `security_state` table to track security settings

## Testing
- `alembic upgrade head`
- `curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8001/api/security/chain`
- `pytest tests/test_security_toggle.py::test_chain_persists_across_clients -p no:warnings`

------
https://chatgpt.com/codex/tasks/task_e_6895dfc6f0e0832e9651ac9b623d404b