### PR TITLE
Expose stolen cart items in attack simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,16 @@ server starts your default browser opens the shop home page automatically at
   user's cart from Demo Shop, demonstrating how Alice's data is exposed while
   Ben remains safe.
 
+2. Before running the simulator, add an item to Alice's cart in the Demo Shop.
+   Visit <http://localhost:3005>, log in as Alice (password `secret`), and
+   click **Add to cart** for any product. The simulator will capture these
+   items on the first successful login.
 
-2. Log in and locate the **Credential Stuffing Simulation** section. Choose a
+3. Log in and locate the **Credential Stuffing Simulation** section. Choose a
    target account and click **Start Attack**. When targeting Alice the attack
    will usually succeed quickly. Ben's account requires the correct chain token
    so repeated guesses are blocked.
-
-3. To use the command-line to login and create a user that would be used across the services and for the 
+4. To use the command-line to login and create a user that would be used across the services and for the
    purpose of testing we need to use the terminal, below is an example of how to register a user and login
    
    ```

--- a/frontend/src/AttackSim.jsx
+++ b/frontend/src/AttackSim.jsx
@@ -35,6 +35,18 @@ export default function AttackSim({ user }) {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ username: name, password: info.password }),
           });
+          await fetch(`${SHOP_URL}/login`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ username: name, password: info.password }),
+            credentials: "include",
+          });
+          await fetch(`${SHOP_URL}/cart`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ productId: 1 }),
+            credentials: "include",
+          });
         } catch (err) {
           // ignore errors (likely already registered)
         }
@@ -261,12 +273,10 @@ export default function AttackSim({ user }) {
                 </p>
               )}
               {results.first_cart && (
-                <div>
-                  <p>Cart</p>
-                  <pre>
-                    <code>{JSON.stringify(results.first_cart, null, 2)}</code>
-                  </pre>
-                </div>
+                <>
+                  <h4>Stolen Cart Items</h4>
+                  <pre>{JSON.stringify(results.first_cart, null, 2)}</pre>
+                </>
               )}
             </>
           )}


### PR DESCRIPTION
## Summary
- Seed demo shop carts by logging in and adding a product for each user
- Render stolen cart items in attack simulator results
- Clarify in README to add items to Alice's cart before running the simulator

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68963501069c832ead3e1e7e4d0ad709