### PR TITLE
Fix audit log URL

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -2,7 +2,7 @@ const API_BASE = 'http://localhost:3005';
 const TOKEN_KEY = 'apiShieldAuthToken';
 
 const AUTH_TOKEN_KEY = 'apiShieldAuthToken';
-const AUDIT_URL = 'http://localhost:8000/api/audit/log';
+const AUDIT_URL = `${API_BASE.replace('3005', '8001')}/api/audit/log`;
 
 let username = null;
 


### PR DESCRIPTION
## Summary
- derive audit log endpoint from API_BASE to use correct port 8001

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest tests/test_audit.py -q`
- `node -e "fetch('http://localhost:8001/api/audit/log',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({event:'user_login_success',username:'alice'})}).then(r=>r.text()).then(console.log);"`

------
https://chatgpt.com/codex/tasks/task_e_689636d8e8c0832ea243f7d4f67c4797