### PR TITLE
feat: allow audit URL override for audit service

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -2,7 +2,10 @@ const API_BASE = 'http://localhost:3005';
 const TOKEN_KEY = 'apiShieldAuthToken';
 
 const AUTH_TOKEN_KEY = 'apiShieldAuthToken';
-const AUDIT_URL = `${API_BASE.replace('3005', '8001')}/api/audit/log`;
+// Allow overriding the audit service base URL via environment variables; otherwise
+// replace any port in API_BASE with :8001 for local development.
+const AUDIT_BASE = process?.env?.AUDIT_URL || API_BASE.replace(/:\d+/, ':8001');
+const AUDIT_URL = `${AUDIT_BASE}/api/audit/log`;
 
 let username = null;
 


### PR DESCRIPTION
## Summary
- allow audit service URL to be overridden and default to port 8001

## Testing
- `node --check shop-ui/app.js`
- `curl http://localhost:8001/ping`
- `curl -c cookies.txt -H 'Content-Type: application/json' -d '{"username": "alice", "password": "secret"}' http://localhost:3005/login`
- `curl -H 'Content-Type: application/json' -d '{"event": "user_login_success", "username": "alice"}' http://localhost:8001/api/audit/log`
- `curl -b cookies.txt -H 'Content-Type: application/json' -d '{}' http://localhost:3005/logout`
- `curl -H 'Content-Type: application/json' -d '{"event": "user_logout", "username": "alice"}' http://localhost:8001/api/audit/log`


------
https://chatgpt.com/codex/tasks/task_e_6896419345d0832ea6703c1ff5d326c9