### PR TITLE
feat: safely resolve audit service URL

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -4,7 +4,14 @@ const TOKEN_KEY = 'apiShieldAuthToken';
 const AUTH_TOKEN_KEY = 'apiShieldAuthToken';
 // Allow overriding the audit service base URL via environment variables; otherwise
 // replace any port in API_BASE with :8001 for local development.
-const AUDIT_BASE = process?.env?.AUDIT_URL || API_BASE.replace(/:\d+/, ':8001');
+const envAudit =
+  typeof process !== 'undefined' && process.env
+    ? process.env.REACT_APP_AUDIT_URL
+    : undefined;
+const AUDIT_BASE =
+  window.location.hostname === 'localhost'
+    ? API_BASE.replace(/:\d+/, ':8001')
+    : envAudit || API_BASE.replace(/:\d+/, ':8001');
 const AUDIT_URL = `${AUDIT_BASE}/api/audit/log`;
 
 let username = null;


### PR DESCRIPTION
## Summary
- avoid referencing undefined `process` by safely reading audit URL
- adjust audit base resolution for local vs deployed environments

## Testing
- `node -c shop-ui/app.js`
- `node -e "global.window={location:{hostname:'example.com'}};global.process=undefined;const API_BASE='http://localhost:3005';const envAudit=typeof process !== 'undefined' && process.env?process.env.REACT_APP_AUDIT_URL:undefined;const AUDIT_BASE=window.location.hostname==='localhost'?API_BASE.replace(/:\d+/,':8001'):envAudit||API_BASE.replace(/:\d+/,':8001');console.log('AUDIT_BASE',AUDIT_BASE);"`

------
https://chatgpt.com/codex/tasks/task_e_689649b8cca0832eb18155ff6697a8fa