### PR TITLE
Bypass OPTIONS and audit log in zero trust middleware

### DIFF
--- a/backend/app/core/zero_trust.py
+++ b/backend/app/core/zero_trust.py
@@ -17,6 +17,8 @@ class ZeroTrustMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         if request.url.path in {"/ping", "/login", "/register", "/api/token"}:
             return await call_next(request)
+        if request.method == "OPTIONS" or request.url.path == "/api/audit/log":
+            return await call_next(request)
         header = request.headers.get("X-API-Key")
         if header != API_KEY:
             client_ip = request.client.host if request.client else "unknown"


### PR DESCRIPTION
## Summary
- allow OPTIONS requests and audit log endpoint to bypass API key enforcement

## Testing
- `pytest`
- `ps aux | grep python | grep server.py`


------
https://chatgpt.com/codex/tasks/task_e_689654431178832ea6287de37b7f03fd