### PR TITLE
Fix duplicate load_creds definition and REQUEST_TIMEOUT

### DIFF
--- a/scripts/stuffing.py
+++ b/scripts/stuffing.py
@@ -12,17 +12,11 @@ ROCKYOU_PATH = Path(__file__).with_name("data").joinpath("rockyou.txt")
 REQUEST_TIMEOUT = 3
 
 
-def load_creds(path: Union[Path, str] = ROCKYOU_PATH, limit: Optional[int] = None):
-
-
-REQUEST_TIMEOUT = 3
-
-
 def load_creds(
     path: Union[Path, str, None] = ROCKYOU_PATH, limit: Optional[int] = None
 ):
 
-  """Load credentials from a file with an optional limit.
+    """Load credentials from a file with an optional limit.
 
     *path* may be a :class:`pathlib.Path` or string. By default the bundled
     ``rockyou.txt`` file located in the ``data`` directory alongside this


### PR DESCRIPTION
## Summary
- remove stray load_creds declaration and redundant REQUEST_TIMEOUT from stuffing script

## Testing
- `pytest`
- `python -m py_compile scripts/stuffing.py`


------
https://chatgpt.com/codex/tasks/task_e_68965a61ddcc832eb9be2f677978b278