### PR TITLE
Align hostnames and streamline auth headers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,12 @@ from app.api.audit import router as audit_router
 
 app = FastAPI(title="APIShield+")
 
-allow_origins = ["http://localhost:3000"]
+allow_origins = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:3005",
+    "http://127.0.0.1:3005",
+]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allow_origins,

--- a/demo-shop/package-lock.json
+++ b/demo-shop/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.6.8",
         "body-parser": "^1.20.2",
+        "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-session": "^1.17.3"
       }
@@ -146,6 +147,19 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -605,6 +619,15 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/demo-shop/package.json
+++ b/demo-shop/package.json
@@ -10,6 +10,7 @@
     "axios": "^1.6.8",
     "body-parser": "^1.20.2",
     "express": "^4.18.2",
-    "express-session": "^1.17.3"
+    "express-session": "^1.17.3",
+    "cors": "^2.8.5"
   }
 }

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -4,8 +4,10 @@ const bodyParser = require('body-parser');
 const axios = require('axios');
 const path = require('path');
 const { spawn } = require('child_process');
+const cors = require('cors');
 
 const app = express();
+app.use(cors({ origin: ["http://localhost:3000","http://127.0.0.1:3000"], credentials: true }));
 const PORT = process.env.PORT || 3005;
 const API_BASE = process.env.API_BASE || 'http://localhost:8001';
 const API_TIMEOUT = parseInt(process.env.API_TIMEOUT_MS || '10000', 10);

--- a/frontend/.env
+++ b/frontend/.env
@@ -3,3 +3,5 @@
 # If the API runs elsewhere, set REACT_APP_API_BASE to the full URL, e.g.:
 # REACT_APP_API_BASE=https://api.example.com
 # REACT_APP_API_BASE=http://localhost:8001
+REACT_APP_API_BASE=http://127.0.0.1:8001
+REACT_APP_SHOP_URL=http://127.0.0.1:3005

--- a/frontend/src/AlertsTable.jsx
+++ b/frontend/src/AlertsTable.jsx
@@ -1,15 +1,13 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function AlertsTable({ refresh, token }) {
+export default function AlertsTable({ refresh }) {
   const [alerts, setAlerts] = useState([]);
   const [error, setError] = useState(null);
 
   const loadAlerts = async () => {
     try {
-      // Only include Authorization header when a token is available
-      const headers = token ? { Authorization: `Bearer ${token}` } : {};
-      const resp = await apiFetch("/api/alerts", { headers, skipReauth: true });
+      const resp = await apiFetch("/api/alerts", { skipReauth: true });
       if (!resp.ok) throw new Error(await resp.text());
       setAlerts(await resp.json());
     } catch (err) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -75,10 +75,10 @@ function App() {
         <AlertsChart token={token} />
       </div>
       <div className="dashboard-section">
-        <AlertsTable refresh={refreshKey} token={token} />
+        <AlertsTable refresh={refreshKey} />
       </div>
       <div className="dashboard-section">
-        <EventsTable token={token} />
+        <EventsTable />
       </div>
       <div className="dashboard-section">
         <div className="attack-section">

--- a/frontend/src/EventsTable.jsx
+++ b/frontend/src/EventsTable.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function EventsTable({ token }) {
+export default function EventsTable() {
   const [events, setEvents] = useState([]);
   const [error, setError] = useState(null);
   const [hours, setHours] = useState(24);
@@ -9,10 +9,7 @@ export default function EventsTable({ token }) {
   const load = async () => {
     const query = hours ? `?hours=${hours}` : "";
     try {
-      const resp = await apiFetch(`/api/events${query}`, {
-        headers: { Authorization: `Bearer ${token}` },
-        skipReauth: true,
-      });
+      const resp = await apiFetch(`/api/events${query}`, { skipReauth: true });
       if (!resp.ok) throw new Error(await resp.text());
       setEvents(await resp.json());
     } catch (err) {

--- a/frontend/src/LoginStatus.jsx
+++ b/frontend/src/LoginStatus.jsx
@@ -7,10 +7,7 @@ export default function LoginStatus({ token }) {
 
   const load = async () => {
     try {
-      const resp = await apiFetch("/api/last-logins", {
-        headers: { Authorization: `Bearer ${token}` },
-        skipReauth: true,
-      });
+      const resp = await apiFetch("/api/last-logins", { skipReauth: true });
       if (!resp.ok) throw new Error(await resp.text());
       setLogins(await resp.json());
     } catch (err) {


### PR DESCRIPTION
## Summary
- Expand backend CORS allowlist for dashboard and shop hosts
- Set frontend API and shop URLs and enable CORS in demo shop
- Drop manual Authorization headers; rely on apiFetch token injection

## Testing
- `pytest`
- `npm test -- --watchAll=false` (frontend)
- `npm test` (demo-shop; fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68965a3ba918832eb3256d58c0d1d7a0