### PR TITLE
Add authentication event audit trail

### DIFF
--- a/backend/alembic/versions/bac9ef8f94da_create_auth_events_table.py
+++ b/backend/alembic/versions/bac9ef8f94da_create_auth_events_table.py
@@ -1,0 +1,45 @@
+"""create auth_events table
+
+Revision ID: bac9ef8f94da
+Revises: fffff
+Create Date: 2025-08-09 08:47:23.879942
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'bac9ef8f94da'
+down_revision: Union[str, None] = 'fffff'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auth_events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user", sa.String(), nullable=True),
+        sa.Column("action", sa.String(), nullable=False),
+        sa.Column(
+            "success", sa.Boolean(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(op.f("ix_auth_events_id"), "auth_events", ["id"], unique=False)
+    op.create_index(
+        op.f("ix_auth_events_created_at"),
+        "auth_events",
+        ["created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_auth_events_created_at"), table_name="auth_events")
+    op.drop_index(op.f("ix_auth_events_id"), table_name="auth_events")
+    op.drop_table("auth_events")

--- a/backend/app/api/auth_events.py
+++ b/backend/app/api/auth_events.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.db import get_db
+from app.schemas.auth_events import AuthEventCreate, AuthEventOut
+from app.crud.auth_events import create_auth_event, get_auth_events
+
+router = APIRouter(prefix="/events", tags=["auth-events"])
+
+
+@router.post("/auth", response_model=AuthEventOut)
+def log_auth_event(payload: AuthEventCreate, db: Session = Depends(get_db)) -> AuthEventOut:
+    return create_auth_event(db, payload.user, payload.action, payload.success, payload.source)
+
+
+@router.get("/auth", response_model=List[AuthEventOut])
+def read_auth_events(
+    limit: int = 50, offset: int = 0, db: Session = Depends(get_db)
+) -> List[AuthEventOut]:
+    return get_auth_events(db, limit=limit, offset=offset)

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -1,6 +1,7 @@
 from .alerts import get_all_alerts
 from .users import get_user_by_username, create_user
 from .events import create_event, get_events
+from .auth_events import create_auth_event, get_auth_events
 from .policies import get_policy_by_id, create_policy, get_policy_for_user
 from .audit import create_audit_log
 
@@ -10,6 +11,8 @@ __all__ = [
     "create_user",
     "create_event",
     "get_events",
+    "create_auth_event",
+    "get_auth_events",
     "get_policy_by_id",
     "create_policy",
     "get_policy_for_user",

--- a/backend/app/crud/auth_events.py
+++ b/backend/app/crud/auth_events.py
@@ -1,0 +1,23 @@
+from sqlalchemy.orm import Session
+
+from app.models.auth_events import AuthEvent
+
+
+def create_auth_event(
+    db: Session, user: str | None, action: str, success: bool, source: str
+) -> AuthEvent:
+    event = AuthEvent(user=user, action=action, success=success, source=source)
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+def get_auth_events(db: Session, limit: int = 50, offset: int = 0) -> list[AuthEvent]:
+    return (
+        db.query(AuthEvent)
+        .order_by(AuthEvent.id.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.api.events import router as events_router
 from app.api.last_logins import router as last_logins_router
 from app.api.access_logs import router as access_logs_router
 from app.api.audit import router as audit_router
+from app.api.auth_events import router as auth_events_router
 
 app = FastAPI(title="APIShield+")
 
@@ -64,6 +65,7 @@ app.include_router(events_router)   # /api/events
 app.include_router(last_logins_router)  # /api/last-logins
 app.include_router(access_logs_router)  # /api/access-logs
 app.include_router(audit_router)  # /api/audit/log
+app.include_router(auth_events_router)  # /events/auth
 
 
 @app.get("/ping")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,5 +4,14 @@ from .events import Event
 from .access_logs import AccessLog
 from .policies import Policy
 from .audit_logs import AuditLog
+from .auth_events import AuthEvent
 
-__all__ = ["Alert", "User", "Event", "AccessLog", "Policy", "AuditLog"]
+__all__ = [
+    "Alert",
+    "User",
+    "Event",
+    "AccessLog",
+    "Policy",
+    "AuditLog",
+    "AuthEvent",
+]

--- a/backend/app/models/auth_events.py
+++ b/backend/app/models/auth_events.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime
+
+from app.core.db import Base
+
+
+class AuthEvent(Base):
+    __tablename__ = "auth_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user = Column(String, nullable=True)
+    action = Column(String, nullable=False)
+    success = Column(Boolean, nullable=False, default=False)
+    source = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, index=True)

--- a/backend/app/schemas/auth_events.py
+++ b/backend/app/schemas/auth_events.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AuthEventCreate(BaseModel):
+    user: Optional[str] = None
+    action: str
+    success: bool
+    source: str
+
+
+class AuthEventOut(BaseModel):
+    id: int
+    user: Optional[str]
+    action: str
+    success: bool
+    source: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary
- track authentication events in new `auth_events` table
- expose `/events/auth` endpoints for creating and listing events
- wire router and migration for auth event auditing

## Testing
- `pytest`
- `flake8 app/api/auth_events.py app/models/auth_events.py app/schemas/auth_events.py app/crud/auth_events.py alembic/versions/bac9ef8f94da_create_auth_events_table.py`


------
https://chatgpt.com/codex/tasks/task_e_689708ed6464832e994955fc6496486f