### PR TITLE
feat: add auth events table to dashboard

### DIFF
--- a/frontend/src/AuthEventsTable.jsx
+++ b/frontend/src/AuthEventsTable.jsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { apiFetch } from "./api";
+
+export default function AuthEventsTable({ refresh, limit = 50 }) {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const resp = await apiFetch(`/events/auth?limit=${limit}`, { skipReauth: true });
+      if (!resp.ok) throw new Error(await resp.text());
+      setEvents(await resp.json());
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refresh, limit]);
+
+  return (
+    <div>
+      <button onClick={load}>Refresh</button>
+      {error ? (
+        <p className="error-text">{error}</p>
+      ) : loading ? (
+        <p>Loading…</p>
+      ) : events.length === 0 ? (
+        <p>No events yet.</p>
+      ) : (
+        <table className="alerts-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>User</th>
+              <th>Action</th>
+              <th>Success</th>
+              <th>Source</th>
+              <th>Timestamp</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((e) => (
+              <tr key={e.id}>
+                <td>{e.id}</td>
+                <td>{e.user ?? ""}</td>
+                <td>{e.action}</td>
+                <td>{e.success ? "yes" : "no"}</td>
+                <td>{e.source}</td>
+                <td>
+                  {new Date(e.created_at).toLocaleString("en-GB", { hour12: false })}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import ScoreForm from "../ScoreForm";
 import AlertsTable from "../AlertsTable";
+import AuthEventsTable from "../AuthEventsTable";
 import { apiFetch, AUTH_TOKEN_KEY } from "../api";
 
 function Dashboard() {
@@ -28,6 +29,7 @@ function Dashboard() {
       <hr style={{ margin: "2rem 0" }} />
 
       <AlertsTable token={token} refresh={refresh} />
+      <AuthEventsTable refresh={refresh} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `AuthEventsTable` component to display recent auth activity
- render auth activity on dashboard with refresh support

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68971064d998832e933779e3ba5a69a8