### PR TITLE
docs(demo-shop): clarify auth event configuration

### DIFF
--- a/demo-shop/.env.example
+++ b/demo-shop/.env.example
@@ -2,4 +2,5 @@ FORWARD_API=true
 API_BASE=http://127.0.0.1:8001
 API_KEY=demo-key
 API_TIMEOUT_MS=5000
+# APIShield backend URL for auth events
 APISHIELD_URL=http://localhost:8001

--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -114,9 +114,10 @@ app.post('/login', async (req, res) => {
   const { username, password } = req.body;
   const ok = !!users[username] && users[username].password === password;
 
+  // Notify APIShield+ about each login attempt
   sendAuthEvent({
     user: username || null,
-    action: 'login',
+    action: 'demo-shop',
     success: !!ok,
     source: 'demo-shop',
   });


### PR DESCRIPTION
## Summary
- document APIShield auth event configuration in `.env.example`
- send auth events with `demo-shop` action for login attempts

## Testing
- `npm test` *(fails: Missing script "test" and npm warns Unknown env config "http-proxy". This will stop working in the next major version of npm.)*

------
https://chatgpt.com/codex/tasks/task_e_68973e73c7dc832e87b4f4b436d7af97