### PR TITLE
Emit auth events on logout

### DIFF
--- a/demo-shop/server.js
+++ b/demo-shop/server.js
@@ -226,8 +226,21 @@ app.post('/logout', async (req, res) => {
       console.error('Audit log failed', e);
     }
   }
+  const username = req.session.username;
   req.session.apiToken = null;
-  req.session.destroy(() => res.json({ status: 'ok' }));
+  req.session.destroy(err => {
+    sendAuthEvent({
+      user: username || null,
+      action: 'demo-shop',
+      success: !err,
+      source: 'demo-shop',
+    });
+    if (err) {
+      console.error('Session destruction failed', err);
+      return res.status(500).json({ status: 'error' });
+    }
+    res.json({ status: 'ok' });
+  });
 });
 
 // Report whether the current session is authenticated


### PR DESCRIPTION
## Summary
- notify APIShield+ of logout attempts with sendAuthEvent
- capture username before destroying session and report success/failure

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689750d06970832e94528c1806639c67