### PR TITLE
Log success events for stuffing attempts

### DIFF
--- a/backend/app/api/score.py
+++ b/backend/app/api/score.py
@@ -83,6 +83,7 @@ def record_attempt(
     if success:
         if user_id is not None:
             FAILED_USER_ATTEMPTS.pop(user_id, None)
+        log_event(db, None, "stuffing_attempt", True)
         return {"status": "ok", "fails_last_minute": 0}
 
     ip_fail_limit = int(os.getenv("FAIL_LIMIT", DEFAULT_FAIL_LIMIT))


### PR DESCRIPTION
## Summary
- record successful login attempts in event log

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689752c0aed4832e9f518dcd871d400f