### PR TITLE
Add audit_logs table migration

### DIFF
--- a/backend/alembic/versions/c71d79a6adbb_create_audit_logs_table.py
+++ b/backend/alembic/versions/c71d79a6adbb_create_audit_logs_table.py
@@ -1,0 +1,40 @@
+"""create audit_logs table
+
+Revision ID: c71d79a6adbb
+Revises: bac9ef8f94da
+Create Date: 2025-08-09 14:28:08.026118
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c71d79a6adbb'
+down_revision: Union[str, None] = 'bac9ef8f94da'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("username", sa.String(), nullable=True),
+        sa.Column("event", sa.String(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+    )
+    op.create_index(op.f("ix_audit_logs_id"), "audit_logs", ["id"], unique=False)
+    op.create_index(
+        op.f("ix_audit_logs_username"), "audit_logs", ["username"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_audit_logs_username"), table_name="audit_logs")
+    op.drop_index(op.f("ix_audit_logs_id"), table_name="audit_logs")
+    op.drop_table("audit_logs")


### PR DESCRIPTION
## Summary
- add Alembic migration for new `audit_logs` table with id, username, event, and timestamp columns
## Testing
- `alembic upgrade head`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689759f1ba58832eb933be50cf583767