### PR TITLE
Apply Alembic migrations in tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,32 @@
+import os
 import sys
 from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
 
 # Ensure the backend package is on the Python path so tests can import app.*
 backend_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(backend_root))
+
+
+@pytest.fixture(autouse=True)
+def apply_migrations():
+    """Apply Alembic migrations for a clean database before each test."""
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        # Tests that don't touch the DB can skip migrations.
+        yield
+        return
+
+    from app.core.db import SessionLocal
+
+    cfg = Config(str(backend_root / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    command.upgrade(cfg, "head")
+    try:
+        yield
+    finally:
+        SessionLocal().close()
+        command.downgrade(cfg, "base")

--- a/backend/tests/test_access_logs.py
+++ b/backend/tests/test_access_logs.py
@@ -5,7 +5,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.core.security import create_access_token, get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 
@@ -13,14 +13,8 @@ client = TestClient(app)
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username='alice', password_hash=get_password_hash('pw'))
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_access_logs_recorded():

--- a/backend/tests/test_anomaly.py
+++ b/backend/tests/test_anomaly.py
@@ -5,23 +5,12 @@ from fastapi.testclient import TestClient
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
 
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
-
 import app.main as main_module  # noqa: E402
 
 
 def _reload_app() -> TestClient:
     importlib.reload(main_module)
     return TestClient(main_module.app)
-
-
-def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_anomalous_path_blocked_iforest(monkeypatch):

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -5,19 +5,10 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.models.audit_logs import AuditLog  # noqa: E402
 
 client = TestClient(app)
-
-
-def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_audit_log_persists_event():

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -7,20 +7,10 @@ from datetime import timedelta  # noqa: E402
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
 from app.core.config import settings  # noqa: E402
 import app.api.auth as auth_module  # noqa: E402
 
 client = TestClient(app)
-
-
-def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_register_and_login():

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -5,7 +5,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import SessionLocal, Base, engine  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 
@@ -13,8 +13,6 @@ client = TestClient(app)
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username="admin", password_hash=get_password_hash("pw"), role="admin")
 

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -6,7 +6,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 
@@ -14,14 +14,8 @@ client = TestClient(app)
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username='alice', password_hash=get_password_hash('pw'))
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_login_event_logged():

--- a/backend/tests/test_last_logins.py
+++ b/backend/tests/test_last_logins.py
@@ -4,7 +4,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.core.security import create_access_token, get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 
@@ -12,15 +12,9 @@ client = TestClient(app)
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username='alice', password_hash=get_password_hash('pw'))
         create_user(db, username='ben', password_hash=get_password_hash('pw2'))
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_last_login_endpoint():

--- a/backend/tests/test_me_endpoint.py
+++ b/backend/tests/test_me_endpoint.py
@@ -5,7 +5,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 
@@ -13,14 +13,8 @@ client = TestClient(app)
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username='alice', password_hash=get_password_hash('pw'))
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def _auth_headers():

--- a/backend/tests/test_policies.py
+++ b/backend/tests/test_policies.py
@@ -5,7 +5,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 from app.crud.policies import create_policy  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
@@ -14,8 +14,6 @@ client = TestClient(app)
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         strict = create_policy(db, failed_attempts_limit=1)
         lenient = create_policy(db, failed_attempts_limit=3)
@@ -31,10 +29,6 @@ def setup_function(_):
             password_hash=get_password_hash('pw'),
             policy_id=lenient.id,
         )
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_policy_enforcement():

--- a/backend/tests/test_reauth.py
+++ b/backend/tests/test_reauth.py
@@ -1,7 +1,11 @@
 import importlib
+import os
+
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
+os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 
@@ -15,14 +19,8 @@ def _reload_app():
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username="alice", password_hash=get_password_hash("pw"))
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_missing_password_header(monkeypatch):

--- a/backend/tests/test_score.py
+++ b/backend/tests/test_score.py
@@ -7,7 +7,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.models.alerts import Alert  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
@@ -26,14 +26,8 @@ def current_chain():
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username='admin', password_hash=get_password_hash('pw'), role='admin')
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_block_after_five_failures():

--- a/backend/tests/test_security_toggle.py
+++ b/backend/tests/test_security_toggle.py
@@ -6,7 +6,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
 
@@ -14,8 +14,6 @@ client = TestClient(app)
 
 
 def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     # reset flag for each test
     from app.api import security
     security.SECURITY_ENABLED = True
@@ -29,8 +27,6 @@ def _auth_headers():
     return {'Authorization': f'Bearer {token}'}
 
 
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_get_security_default():

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -6,7 +6,7 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.models.alerts import Alert  # noqa: E402
 from app.core.security import create_access_token, get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
@@ -14,13 +14,6 @@ from app.crud.users import create_user  # noqa: E402
 client = TestClient(app)
 
 
-def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_stats_endpoint():

--- a/backend/tests/test_user_calls.py
+++ b/backend/tests/test_user_calls.py
@@ -5,20 +5,13 @@ os.environ['SECRET_KEY'] = 'test-secret'
 
 from fastapi.testclient import TestClient  # noqa: E402
 from app.main import app  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.core.security import create_access_token, get_password_hash  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 
 client = TestClient(app)
 
 
-def setup_function(_):
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-
-
-def teardown_function(_):
-    SessionLocal().close()
 
 
 def test_user_call_counter():

--- a/backend/tests/test_zero_trust.py
+++ b/backend/tests/test_zero_trust.py
@@ -1,12 +1,15 @@
 import os
 
+import importlib  # noqa: E402
+import os
+
 os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 os.environ['SECRET_KEY'] = 'test-secret'
+
 from fastapi.testclient import TestClient  # noqa: E402
-import importlib  # noqa: E402
 import app.core.zero_trust as zero_trust  # noqa: E402
 import app.main as main_module  # noqa: E402
-from app.core.db import Base, engine, SessionLocal  # noqa: E402
+from app.core.db import SessionLocal  # noqa: E402
 from app.crud.users import create_user  # noqa: E402
 from app.core.security import get_password_hash  # noqa: E402
 
@@ -20,8 +23,6 @@ def setup_function(_):
     importlib.reload(main_module)
     global client
     client = TestClient(main_module.app)
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     with SessionLocal() as db:
         create_user(db, username='admin', password_hash=get_password_hash('pw'), role='admin')
 
@@ -33,7 +34,6 @@ def _auth_headers():
 
 
 def teardown_function(_):
-    SessionLocal().close()
     os.environ.pop('ZERO_TRUST_API_KEY', None)
     importlib.reload(zero_trust)
     importlib.reload(main_module)


### PR DESCRIPTION
## Summary
- run Alembic migrations before tests via new `apply_migrations` fixture
- refactor DB tests to rely on migrations instead of `Base.metadata.create_all`

## Testing
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_689761596900832ea5a0d9f4ecdaf712