### PR TITLE
Apply design classes to Dashboard tables

### DIFF
--- a/frontend/src/AlertsTable.jsx
+++ b/frontend/src/AlertsTable.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function AlertsTable({ refresh }) {
+export default function AlertsTable({ refresh, tableClassName = "table" }) {
   const [alerts, setAlerts] = useState([]);
   const [error, setError] = useState(null);
 
@@ -24,7 +24,7 @@ export default function AlertsTable({ refresh }) {
   if (alerts.length === 0) return <p>No alerts yet.</p>;
 
   return (
-    <table className="alerts-table">
+    <table className={tableClassName}>
       <thead>
         <tr>
           <th>ID</th>

--- a/frontend/src/AuthEventsTable.jsx
+++ b/frontend/src/AuthEventsTable.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "./api";
 
-export default function AuthEventsTable({ refresh, limit = 50 }) {
+export default function AuthEventsTable({ refresh, limit = 50, tableClassName = "table" }) {
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -35,7 +35,7 @@ export default function AuthEventsTable({ refresh, limit = 50 }) {
       ) : events.length === 0 ? (
         <p>No events yet.</p>
       ) : (
-        <table className="alerts-table">
+        <table className={tableClassName}>
           <thead>
             <tr>
               <th>ID</th>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -20,16 +20,33 @@ function Dashboard() {
   const handleNewAlert = () => setRefresh((r) => r + 1);
 
   return (
-    <div style={{ padding: "1rem" }}>
-      <h1>APIShield+ Dashboard</h1>
-      <p>Backend ping says: {ping ?? "Loading…"} </p>
+    <div className="container stack">
+      <header className="dashboard-header">
+        <h1>APIShield+ Dashboard</h1>
+        <p className="subtle">Backend ping says: {ping ?? "Loading…"} </p>
+      </header>
 
-      <ScoreForm token={token} onNewAlert={handleNewAlert} />
+      <section className="card">
+        <div className="card-header">
+          <div className="card-title">Risk Scoring</div>
+        </div>
+        <ScoreForm token={token} onNewAlert={handleNewAlert} />
+      </section>
 
-      <hr style={{ margin: "2rem 0" }} />
+      <section className="card">
+        <div className="card-header">
+          <div className="card-title">Alerts</div>
+        </div>
+        <AlertsTable token={token} refresh={refresh} tableClassName="table" />
+      </section>
 
-      <AlertsTable token={token} refresh={refresh} />
-      <AuthEventsTable refresh={refresh} />
+      {/* If you added AuthEventsTable previously */}
+      <section className="card">
+        <div className="card-header">
+          <div className="card-title">Recent Auth Activity</div>
+        </div>
+        <AuthEventsTable refresh={refresh} />
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace Dashboard inline styles with `.container`, `.card`, and headers
- ensure AlertsTable and AuthEventsTable tables use `.table` class

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68979bca7d4c832e8e867a65f9e1f759