### PR TITLE
feat: restyle login page to match dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,14 +41,7 @@ function App() {
   }, [token]);
 
   if (!token) {
-    return (
-      <div className="app-container">
-        <h1 className="dashboard-header">Please log in</h1>
-        <div className="dashboard-section">
-          <LoginForm onLogin={setToken} />
-        </div>
-      </div>
-    );
+    return <LoginForm onLogin={setToken} />;
   }
 
   return (

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -3,6 +3,6 @@ import App from './App';
 
 test('renders login header when no token is present', () => {
   render(<App />);
-  const headerElement = screen.getByRole('heading', { name: /please log in/i });
+  const headerElement = screen.getByRole('heading', { name: /sign in/i });
   expect(headerElement).toBeInTheDocument();
 });

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -6,7 +6,7 @@ export default function LoginForm({ onLogin }) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState(null);
 
-  const handleSubmit = async e => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setError(null);
     try {
@@ -29,17 +29,53 @@ export default function LoginForm({ onLogin }) {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <label>
-        Username:
-        <input value={username} onChange={e => setUsername(e.target.value)} />
-      </label>
-      <label>
-        Password:
-        <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
-      </label>
-      <button type="submit">Login</button>
-      {error && <p style={{ color: "red" }}>{error}</p>}
-    </form>
+    <div className="center" style={{ minHeight: "100vh", padding: "2rem" }}>
+      <div className="card" style={{ width: "100%", maxWidth: 420 }}>
+        <div className="card-header">
+          <div className="brand">
+            <span className="brand-mark" />APIShield+
+          </div>
+        </div>
+        <h2 style={{ margin: 0, marginBottom: "0.5rem" }}>Sign in</h2>
+        <p
+          className="subtle"
+          style={{ marginTop: 0, marginBottom: "1rem" }}
+        >
+          Enter your credentials to access the dashboard
+        </p>
+        <form className="form" onSubmit={handleSubmit}>
+          <div className="field">
+            <label className="label">Email</label>
+            <input
+              className="input"
+              name="email"
+              type="email"
+              placeholder="you@company.com"
+              required
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+          </div>
+          <div className="field">
+            <label className="label">Password</label>
+            <input
+              className="input"
+              name="password"
+              type="password"
+              placeholder="••••••••"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <button className="btn" type="submit">
+            Sign in
+          </button>
+        </form>
+        {error && (
+          <p style={{ color: "var(--danger)", marginTop: "1rem" }}>{error}</p>
+        )}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- redesign login form with card layout and brand styling using design tokens
- simplify App login branch to render new LoginForm component
- adjust test to look for new "Sign in" heading

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68979f20e858832eaef588f8f6c3548a