### PR TITLE
feat: add persistent dark mode toggle

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,18 @@ function App() {
   const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
 
+  useEffect(() => {
+    const root = document.documentElement;
+    const pref = localStorage.getItem("theme");
+    if (pref === "dark") root.classList.add("theme-dark");
+  }, []);
+
+  function toggleTheme() {
+    const root = document.documentElement;
+    const dark = root.classList.toggle("theme-dark");
+    localStorage.setItem("theme", dark ? "dark" : "light");
+  }
+
   const handleLogout = async () => {
     const username = localStorage.getItem(USERNAME_KEY);
     await logAuditEvent("user_logout", username);
@@ -48,6 +60,9 @@ function App() {
     <div className="app-container">
       <div className="header">
         <h1 className="dashboard-header">APIShield+ Dashboard</h1>
+        <button className="btn secondary" onClick={toggleTheme}>
+          Toggle theme
+        </button>
         <button className="logout-button" onClick={handleLogout}>
           Logout
         </button>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -6,3 +6,10 @@ test('renders login header when no token is present', () => {
   const headerElement = screen.getByRole('heading', { name: /sign in/i });
   expect(headerElement).toBeInTheDocument();
 });
+
+test('applies dark theme class when preference is dark', () => {
+  localStorage.setItem('theme', 'dark');
+  render(<App />);
+  expect(document.documentElement.classList.contains('theme-dark')).toBe(true);
+  localStorage.removeItem('theme');
+});


### PR DESCRIPTION
## Summary
- add a header button to toggle dark theme
- persist user's theme preference in localStorage
- cover dark theme application with a unit test

## Testing
- `CI=true npm test`
- `node -e "const { JSDOM } = require('jsdom'); const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'https://example.org' }); const root = dom.window.document.documentElement; const localStorage = dom.window.localStorage; function toggleTheme(){const dark=root.classList.toggle('theme-dark');localStorage.setItem('theme', dark ? 'dark' : 'light'); console.log('class:', root.className, 'stored:', localStorage.getItem('theme'));} console.log('initial class:', root.className); toggleTheme(); toggleTheme();"`


------
https://chatgpt.com/codex/tasks/task_e_6897a3925ab8832e8f1f231e7310ae75