### PR TITLE
Improve dashboard layout, dark mode toggle, and login form

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,7 +1,6 @@
 /* Keep app-specific layout helpers; rely on tokens from index.css */
 .app-container { max-width: 1100px; margin: 0 auto; padding: var(--space-8) var(--space-4); }
-.dashboard-section { margin-bottom: var(--space-6); }
-.dashboard-header { text-align:center; margin-bottom: var(--space-6); }
+.dashboard-header { display:flex; justify-content: space-between; align-items: center; margin-bottom: var(--space-6); }
 .dashboard-header h1 { font-size: var(--font-30); margin: 0; }
 .dashboard-grid { display:grid; gap: var(--space-6); grid-template-columns: 1fr; }
 @media (min-width: 980px) { .dashboard-grid { grid-template-columns: 2fr 1fr; } }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,17 +16,20 @@ function App() {
 
   const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
+  const [isDark, setIsDark] = useState(() => localStorage.getItem("theme") === "dark");
 
   useEffect(() => {
     const root = document.documentElement;
-    const pref = localStorage.getItem("theme");
-    if (pref === "dark") root.classList.add("theme-dark");
-  }, []);
+    if (isDark) {
+      root.classList.add("theme-dark");
+    } else {
+      root.classList.remove("theme-dark");
+    }
+    localStorage.setItem("theme", isDark ? "dark" : "light");
+  }, [isDark]);
 
   function toggleTheme() {
-    const root = document.documentElement;
-    const dark = root.classList.toggle("theme-dark");
-    localStorage.setItem("theme", dark ? "dark" : "light");
+    setIsDark((d) => !d);
   }
 
   const handleLogout = async () => {
@@ -57,45 +60,54 @@ function App() {
   }
 
   return (
-    <div className="app-container">
-      <div className="header">
-        <h1 className="dashboard-header">APIShield+ Dashboard</h1>
-        <button className="btn secondary" onClick={toggleTheme}>
-          Toggle theme
-        </button>
-        <button className="logout-button" onClick={handleLogout}>
-          Logout
-        </button>
-      </div>
-      <div className="dashboard-section">
+    <div className="app-container stack">
+      <header className="dashboard-header">
+        <h1>APIShield+ Dashboard</h1>
+        <div className="row">
+          <button className="btn secondary" onClick={toggleTheme}>
+            {isDark ? "Light mode" : "Dark mode"}
+          </button>
+          <button className="btn secondary" onClick={handleLogout}>
+            Logout
+          </button>
+        </div>
+      </header>
+
+      <section className="card">
         <UserAccounts onSelect={setSelectedUser} />
-      </div>
-      <div className="dashboard-section">
+      </section>
+
+      <section className="card">
         <LoginStatus token={token} />
-      </div>
-      <div className="dashboard-section">
+      </section>
+
+      <section className="card">
         <ScoreForm
           token={token}
           onNewAlert={() => setRefreshKey((k) => k + 1)}
         />
-      </div>
-      <div className="dashboard-section">
+      </section>
+
+      <section className="card">
         <AlertsChart token={token} />
-      </div>
-      <div className="dashboard-section">
+      </section>
+
+      <section className="card">
         <AlertsTable refresh={refreshKey} />
-      </div>
-      <div className="dashboard-section">
+      </section>
+
+      <section className="card">
         <EventsTable />
-      </div>
-      <div className="dashboard-section">
+      </section>
+
+      <section className="card">
         <div className="attack-section">
           <AttackSim user={selectedUser} />
           <div className="security-box">
             <SecurityToggle />
           </div>
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -45,12 +45,12 @@ export default function LoginForm({ onLogin }) {
         </p>
         <form className="form" onSubmit={handleSubmit}>
           <div className="field">
-            <label className="label">Email</label>
+            <label className="label">Username</label>
             <input
               className="input"
-              name="email"
-              type="email"
-              placeholder="you@company.com"
+              name="username"
+              type="text"
+              placeholder="alice"
               required
               value={username}
               onChange={(e) => setUsername(e.target.value)}


### PR DESCRIPTION
## Summary
- Revamp dashboard layout using card-based sections and flex header for proper padding
- Add stateful dark mode toggle that persists user preference
- Allow usernames without `@` by switching login field from email to text input

## Testing
- `cd frontend && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ace9b538832eb91995d2a696bc47