### PR TITLE
Fix theme toggle and unify table styling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,14 +16,18 @@ function App() {
 
   const [token, setToken] = useState(localStorage.getItem(AUTH_TOKEN_KEY));
   const [selectedUser, setSelectedUser] = useState("alice");
-  const [isDark, setIsDark] = useState(() => localStorage.getItem("theme") === "dark");
+  const [isDark, setIsDark] = useState(
+    () => localStorage.getItem("theme") === "dark"
+  );
 
   useEffect(() => {
     const root = document.documentElement;
     if (isDark) {
       root.classList.add("theme-dark");
+      root.classList.remove("theme-light");
     } else {
       root.classList.remove("theme-dark");
+      root.classList.add("theme-light");
     }
     localStorage.setItem("theme", isDark ? "dark" : "light");
   }, [isDark]);

--- a/frontend/src/EventsTable.jsx
+++ b/frontend/src/EventsTable.jsx
@@ -32,28 +32,30 @@ export default function EventsTable() {
         <button onClick={() => setHours(1)} className={hours === 1 ? "active" : ""}>1h</button>
         <button onClick={() => setHours(24)} className={hours === 24 ? "active" : ""}>24h</button>
       </div>
-      <table className="alerts-table">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>User</th>
-            <th>Action</th>
-            <th>Success</th>
-            <th>Timestamp</th>
-          </tr>
-        </thead>
-        <tbody>
-          {events.map((e) => (
-            <tr key={e.id}>
-              <td>{e.id}</td>
-              <td>{e.username}</td>
-              <td>{e.action}</td>
-              <td>{e.success ? "yes" : "no"}</td>
-              <td>{new Date(e.timestamp).toLocaleString()}</td>
+      <div style={{ overflowX: "auto" }}>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>User</th>
+              <th>Action</th>
+              <th>Success</th>
+              <th>Timestamp</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {events.map((e) => (
+              <tr key={e.id}>
+                <td>{e.id}</td>
+                <td>{e.username}</td>
+                <td>{e.action}</td>
+                <td>{e.success ? "yes" : "no"}</td>
+                <td>{new Date(e.timestamp).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -44,7 +44,7 @@ button { font: inherit; }
 
 /* Dark theme (opt-in + system) */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not(.theme-light) {
     --bg: #0b1020;
     --panel: #12182a;
     --brand-ink: #e5e7eb;
@@ -122,7 +122,12 @@ body {
   width: 100%; border-collapse: collapse; border: 1px solid var(--border);
   background: var(--panel); border-radius: var(--radius-lg); overflow: hidden;
 }
-.table th, .table td { padding: .75rem 1rem; text-align: left; }
+.table th, .table td {
+  padding: .85rem 1.15rem;
+  text-align: left;
+  margin: 0.1rem;
+  font-size: calc(var(--font-16) + 1pt);
+}
 .table thead th {
   background: linear-gradient(180deg, color-mix(in oklab, var(--brand) 24%, var(--panel)) 0%, color-mix(in oklab, var(--brand) 12%, var(--panel)) 100%);
   color: #fff; position: sticky; top:0; z-index:1;


### PR DESCRIPTION
## Summary
- ensure light mode correctly overrides system dark preference
- enlarge table text with padding/margin and unify events table styling

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6897af1f8344832e9b39056b2866cb6d