### PR TITLE
Fix indentation and duplicate definition in stuffing script

### DIFF
--- a/scripts/stuffing.py
+++ b/scripts/stuffing.py
@@ -12,17 +12,10 @@ ROCKYOU_PATH = Path(__file__).with_name("data").joinpath("rockyou.txt")
 REQUEST_TIMEOUT = 3
 
 
-def load_creds(path: Union[Path, str] = ROCKYOU_PATH, limit: Optional[int] = None):
-
-
-REQUEST_TIMEOUT = 3
-
-
 def load_creds(
-    path: Union[Path, str, None] = ROCKYOU_PATH, limit: Optional[int] = None
+    path: Union[Path, str] = ROCKYOU_PATH, limit: Optional[int] = None
 ):
-
-  """Load credentials from a file with an optional limit.
+    """Load credentials from a file with an optional limit.
 
     *path* may be a :class:`pathlib.Path` or string. By default the bundled
     ``rockyou.txt`` file located in the ``data`` directory alongside this


### PR DESCRIPTION
## Summary
- correct duplicated `load_creds` definition and indentation in `scripts/stuffing.py`
- keep credential loading helper compact and documented

## Testing
- `python scripts/stuffing.py --help`
- `flake8 scripts/stuffing.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897aff869d0832e89a37addb163d17c