### PR TITLE
style: refine spacing in simulation and score sections

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -10,3 +10,10 @@
 .toggle-buttons { display:flex; gap: var(--space-2); }
 .toggle-buttons button { border-radius: var(--radius-sm); border:1px solid var(--border); background: var(--panel); padding: .35rem .6rem; }
 .toggle-buttons button.active { background: var(--brand); color:#fff; border-color: transparent; }
+
+/* Spacing and typography enhancements */
+.attack-sim, .score-form, .user-accounts { padding: var(--space-4); margin: var(--space-4) 0; font-size: var(--font-18); display:flex; flex-direction:column; gap:var(--space-4); }
+.attack-controls, .user-buttons { display:flex; flex-wrap:wrap; gap:var(--space-4); }
+.attack-controls label, .score-form label { display:flex; flex-direction:column; gap:var(--space-2); padding:var(--space-2); }
+.user-buttons button { font-size: var(--font-16); padding:.5rem 1rem; }
+.attack-results p, .score-form p, .user-info p, .user-info li { padding:var(--space-2) 0; }


### PR DESCRIPTION
## Summary
- enhance spacing and typography for attack simulation, score submission, and user account sections

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6897b2113abc832e85102315ced7fb93