### PR TITLE
Add Prometheus metrics for auth events and scrape config

### DIFF
--- a/backend/app/api/auth_events.py
+++ b/backend/app/api/auth_events.py
@@ -1,18 +1,44 @@
 from typing import List
+import time
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 
 from app.core.db import get_db
 from app.schemas.auth_events import AuthEventCreate, AuthEventOut
 from app.crud.auth_events import create_auth_event, get_auth_events
+from app.core.metrics import (
+    record_login_attempt,
+    record_credential_stuffing,
+    record_block,
+    login_request_duration_seconds,
+)
 
 router = APIRouter(prefix="/events", tags=["auth-events"])
 
 
 @router.post("/auth", response_model=AuthEventOut)
-def log_auth_event(payload: AuthEventCreate, db: Session = Depends(get_db)) -> AuthEventOut:
-    return create_auth_event(db, payload.user, payload.action, payload.success, payload.source)
+def log_auth_event(
+    payload: AuthEventCreate, request: Request, db: Session = Depends(get_db)
+) -> AuthEventOut:
+    t0 = time.perf_counter()
+    try:
+        username = (payload.username or "unknown")
+        client_ip = request.client.host if request.client else "unknown"
+        success = bool(payload.success)
+        is_stuff = bool(payload.is_credential_stuffing)
+        blocked = bool(payload.blocked)
+        block_rule = payload.block_rule or ""
+
+        record_login_attempt(username, success)
+        if is_stuff:
+            record_credential_stuffing(username)
+        if blocked:
+            record_block(block_rule, username, client_ip)
+
+        return create_auth_event(db, username, payload.action, success, payload.source)
+    finally:
+        login_request_duration_seconds.observe(time.perf_counter() - t0)
 
 
 @router.get("/auth", response_model=List[AuthEventOut])

--- a/backend/app/api/score.py
+++ b/backend/app/api/score.py
@@ -25,8 +25,8 @@ DEFAULT_FAIL_WINDOW_SECONDS = int(os.getenv("FAIL_WINDOW_SECONDS", "60"))
 
 # Prometheus counter for total login attempts, labeled by IP
 LOGIN_ATTEMPTS = Counter(
-    "login_attempts_total",
-    "Total login attempts",
+    "login_attempts_ip_total",
+    "Total login attempts by IP",
     ["ip"],
 )
 

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -5,6 +5,30 @@ from prometheus_client import Counter, Histogram
 from collections import defaultdict
 from app.core.security import decode_access_token
 
+login_attempts_total = Counter(
+    "login_attempts_total",
+    "Login attempts grouped by outcome and user",
+    ["username", "outcome"],   # outcome: success|fail
+)
+
+credential_stuffing_attempts_total = Counter(
+    "credential_stuffing_attempts_total",
+    "Detected credential stuffing attempts",
+    ["username"],
+)
+
+events_blocked_total = Counter(
+    "events_blocked_total",
+    "Security events blocked by policy/rule",
+    ["rule", "username", "ip"],
+)
+
+login_request_duration_seconds = Histogram(
+    "login_request_duration_seconds",
+    "Login request duration",
+    buckets=[0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+)
+
 REQUEST_LATENCY = Histogram(
     "api_request_latency_seconds",
     "Latency of API requests in seconds",
@@ -35,6 +59,24 @@ def increment_user(user: str) -> None:
 
 def get_user_counts() -> dict[str, int]:
     return dict(_user_counts)
+
+
+def record_login_attempt(username: str, success: bool) -> None:
+    u = (username or "unknown").lower()
+    login_attempts_total.labels(username=u, outcome=("success" if success else "fail")).inc()
+
+
+def record_credential_stuffing(username: str) -> None:
+    u = (username or "unknown").lower()
+    credential_stuffing_attempts_total.labels(username=u).inc()
+
+
+def record_block(rule: str, username: str, ip: str) -> None:
+    events_blocked_total.labels(
+        rule=(rule or "unknown"),
+        username=(username or "unknown").lower(),
+        ip=(ip or "unknown"),
+    ).inc()
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 import os
-from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from app.core.zero_trust import ZeroTrustMiddleware
 from app.core.logging import APILoggingMiddleware
@@ -25,6 +25,11 @@ from app.api.audit import router as audit_router
 from app.api.auth_events import router as auth_events_router
 
 app = FastAPI(title="APIShield+")
+
+
+@app.get("/metrics", include_in_schema=False)
+def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 allow_origins = [
     "http://localhost:3000",
@@ -73,8 +78,3 @@ def ping():
     return {"message": "pong"}
 
 
-@app.get("/metrics")
-def metrics() -> Response:
-    """Expose Prometheus metrics."""
-    data = generate_latest()
-    return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/backend/app/schemas/auth_events.py
+++ b/backend/app/schemas/auth_events.py
@@ -5,10 +5,13 @@ from pydantic import BaseModel
 
 
 class AuthEventCreate(BaseModel):
-    user: Optional[str] = None
-    action: str
+    username: Optional[str] = None
     success: bool
-    source: str
+    is_credential_stuffing: bool = False
+    blocked: bool = False
+    block_rule: Optional[str] = None
+    action: str = "login"
+    source: str = "api"
 
 
 class AuthEventOut(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,4 +12,3 @@ requests==2.32.4
 pytest==8.4.1
 scikit-learn==1.7.0
 numpy==2.3.1
-

--- a/infra/k8s/detector-service.yaml
+++ b/infra/k8s/detector-service.yaml
@@ -9,6 +9,6 @@ spec:
   selector:
     app: detector
   ports:
-  - name: http-metrics
+  - name: http
     port: 8001
     targetPort: 8001

--- a/k8s/monitoring/servicemonitor-detector.yaml
+++ b/k8s/monitoring/servicemonitor-detector.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: detector
+  namespace: monitoring
+  labels:
+    release: kube-prom
+spec:
+  namespaceSelector:
+    matchNames: ["demo"]
+  selector:
+    matchLabels:
+      app: detector
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 15s
+      # scheme: https
+      # tlsConfig:
+      #   insecureSkipVerify: true

--- a/scripts/sim_auth_events.sh
+++ b/scripts/sim_auth_events.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE_URL="${BASE_URL:-http://localhost:8001}"   # use https://localhost:8001 with -k if your dev server has TLS
+CURL_FLAGS=${CURL_FLAGS:-}
+
+post() {
+  user="$1"; success="$2"; stuff="$3"; blocked="$4"; rule="${5:-}"
+  curl -s $CURL_FLAGS -H 'content-type: application/json' -X POST "$BASE_URL/events/auth" \
+    --data "{\"username\":\"$user\",\"success\":$success,\"is_credential_stuffing\":$stuff,\"blocked\":$blocked,\"block_rule\":\"$rule\"}" >/dev/null
+}
+
+echo "Seeding events for alice and ben..."
+post alice false true  true  rate-limit
+post alice false true  false ""
+post ben   false true  true  ip-reputation
+post ben   false false false ""
+post alice true  false false ""
+echo "Done."


### PR DESCRIPTION
## Summary
- add explicit login, credential stuffing, and block counters with histogram helpers
- expose `/metrics` using prometheus_client
- wire auth event endpoint to update metrics and add ServiceMonitor plus sample script

## Testing
- `cd backend && pytest` *(fails: sqlite3.OperationalError: no such index: ix_auth_events_created_at)*

------
https://chatgpt.com/codex/tasks/task_e_689e3bc63fa8832e8ca405d4e0ac4434