### PR TITLE
Poll security toggle to reflect global state

### DIFF
--- a/frontend/src/SecurityToggle.jsx
+++ b/frontend/src/SecurityToggle.jsx
@@ -23,6 +23,11 @@ export default function SecurityToggle() {
     loadState();
   }, []);
 
+  useEffect(() => {
+    const id = setInterval(loadState, 5000);
+    return () => clearInterval(id);
+  }, []);
+
   const toggle = async () => {
     try {
       const resp = await apiFetch("/api/security", {


### PR DESCRIPTION
## Summary
- periodically reload the security toggle so its state is kept in sync across all sessions

## Testing
- `CI=true npm test -- --watchAll=false`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e453a0930832eb65b64473c6e33ab