### PR TITLE
feat: add grafana panel for 403 errors

### DIFF
--- a/grafana/credential-stuffing-barchart.json
+++ b/grafana/credential-stuffing-barchart.json
@@ -39,6 +39,30 @@
         "overrides": []
       },
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 }
+    },
+    {
+      "id": 3,
+      "title": "403 Forbidden Errors",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(api_request_count_total{http_status=\"403\"}[$__range]))",
+          "legendFormat": "403 Forbidden"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list" },
+        "tooltip": { "mode": "single" }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 9 }
     }
   ],
   "refresh": "30s",
@@ -49,5 +73,5 @@
   "time": { "from": "now-6h", "to": "now" },
   "timezone": "",
   "title": "API Credential Stuffing Overview",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
## Summary
- track 403 forbidden errors with a green timeseries panel

## Testing
- `pytest`
- `flake8 grafana/credential-stuffing-barchart.json` *(fails: undefined name 'true' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e4896c450832e8454b2ba1333f1e3