### PR TITLE
fix: include credentials for registration

### DIFF
--- a/shop-ui/app.js
+++ b/shop-ui/app.js
@@ -26,7 +26,7 @@ function setContent(html, callback) {
 
 async function fetchJSON(url, options = {}) {
   const { noAuth, ...opts } = options;
-  const fetchOpts = { headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', ...opts };
+  const fetchOpts = { headers: { 'Content-Type': 'application/json' }, credentials: 'include', ...opts };
   if (!noAuth) {
     const token = localStorage.getItem(AUTH_TOKEN_KEY);
     if (token) {


### PR DESCRIPTION
## Summary
- ensure frontend requests send cookies by using `credentials: 'include'`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ec16a68dc832e935a38dadaf166cf