### PR TITLE
Enable HTTPS for detector ServiceMonitor

### DIFF
--- a/k8s/monitoring/servicemonitor-detector.yaml
+++ b/k8s/monitoring/servicemonitor-detector.yaml
@@ -15,8 +15,6 @@ spec:
     - port: http
       path: /metrics
       interval: 15s
-
-      # If your API serves HTTPS inside the pod, uncomment:
-      # scheme: https
-      # tlsConfig:
-      #   insecureSkipVerify: true
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true


### PR DESCRIPTION
## Summary
- configure detector ServiceMonitor to use HTTPS scheme
- add TLS configuration with insecure skip verify for detector metrics

## Testing
- `kubectl apply -f k8s/monitoring/servicemonitor-detector.yaml` *(fails: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689ed281e204832eb4b017dbbb8be727